### PR TITLE
Update of native-list-dir for GraalVM 1.0.0-rc7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,8 @@ typings/
 # dotenv environment variables file
 .env
 
-
+# Output from native-list-dir module
+extlistdir
+listdir
 
 # End of https://www.gitignore.io/api/java,node,maven,eclipse,intellij+all

--- a/native-list-dir/README.md
+++ b/native-list-dir/README.md
@@ -86,16 +86,16 @@ To compile that class you need to add `graal-sdk.jar` on the classpath:
 $GRAALVM_HOME/bin/javac -cp $GRAALVM_HOME/jre/lib/boot/graal-sdk.jar ExtListDir.java
 ```
 
-Building the native image command is similar to the one above, but since we want to use JavaScript, we need to inform the `native-image` utility about it passing the `--js` option.
+Building the native image command is similar to the one above, but since we want to use JavaScript, we need to inform the `native-image` utility about it passing the `--language:js` option.
 Note that it takes a bit more time because it needs to include the JavaScript support.
 
 ```
-$GRAALVM_HOME/bin/native-image --js ExtListDir
+$GRAALVM_HOME/bin/native-image --language:js ExtListDir
 ```
 
-Executing it is the same as in the previous example:
+Executing it is similar as in the previous example:
 
 ```
-time java ExtListDir $1
-time ./extlistdir $1
+time java ExtListDir
+time ./extlistdir
 ```

--- a/native-list-dir/build.sh
+++ b/native-list-dir/build.sh
@@ -5,4 +5,4 @@ $GRAALVM_HOME/bin/javac ListDir.java
 $GRAALVM_HOME/bin/native-image ListDir
 
 #javac ExtListDir.java
-#$GRAALVM_HOME/bin/native-image --js ExtListDir
+#$GRAALVM_HOME/bin/native-image --language:js ExtListDir


### PR DESCRIPTION
Update of native-list-dir for GraalVM 1.0.0-rc7

 - `--language:js` option instead of `--js` option
 - updated .gitignore
 - update info for execution of ExtListDir case, works just for current dir