### PR TITLE
Adding infrastructure scripts to create capacity for testing

### DIFF
--- a/micronaut-webapp/infrastructure/oci/.gitignore
+++ b/micronaut-webapp/infrastructure/oci/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+*.rc
+*.tfstate*

--- a/micronaut-webapp/infrastructure/oci/README.md
+++ b/micronaut-webapp/infrastructure/oci/README.md
@@ -1,0 +1,77 @@
+#Infrastructure
+
+These scripts give the ability to provision and manage compute capacity using [Oracle Cloud Infrastructure](https://docs.cloud.oracle.com/iaas/Content/services.htm), in
+order to deploy the services shown in this examples. In summary this scripts create computes instances and associated 
+network resources for those instances. It creates a virtual network with a subnet and puts 2 hosts in such subnet.
+It then adds the necessary permissions to allow services to communicate in the subnet within specific ports
+
+Finally it runs init scripts to install basic tool in the hosts
+
+## Pre-requisites
+
+- A properly configured [Oracle Cloud Infrastructure account](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm)
+- [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) 
+  - try `brew install terraform`
+- Create a credentials file called `credentials.rc` for your OCI account. The file should look like the below.
+```
+##Terraform env variables
+export TF_VAR_tenancy_ocid=[TENANCY_OCID]
+export TF_VAR_compartment_ocid=[COMPARMENT_OCID]
+export TF_VAR_user_ocid=[USER_OCID]
+export TF_VAR_fingerprint=[FINGERPRINT]
+export TF_VAR_private_key_path=[PATH_TO_YOUR_ACCOUNT_PRIVATE_KEY eg: ~/.oci/key.pem]
+export TF_VAR_region=[REGION NAME eg: us-ashburn-1]
+
+## ssh keys that will be used for remote access authenication
+export TF_VAR_ssh_public_key="$(cat [PATH_TO_SSH_PUBLIC_KEY])"
+export TF_VAR_ssh_private_key="$(cat [PATH_TO_SSH_PRIVATE_KEY])"
+```
+Notice the `TF_VAR` prefix, keep it so as it is a terraform convention for input variables. More information [here](https://www.terraform.io/docs/providers/oci/index.html)
+
+## Provisioning Infrastructure
+- Sources your credentials file
+
+```$> source credentials.rc```
+
+### Create infrastructure
+
+- Deploy with terraform
+
+```$> terraform init```
+```$> terraform apply --auto-approve```
+
+The deployment process should end with a list of private/public ip addresses like so
+```
+Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+instance_private_ips = [
+    10.1.20.2,
+    10.1.20.3
+]
+instance_public_ips = [
+    1xx.145.174.85,
+    1xx.145.208.127
+]
+
+```
+
+## Deploy your software
+
+- use docker for it
+```$> docker save [DOCKER_IMAGE]|pv|ssh [PUBLIC_IP_ADDRESS] "sudo docker load"```
+
+
+### Destroy infrastructure
+
+- Remove with terraform
+
+```$> terraform destroy --auto-approve```
+
+For more information on terraform infrastructure management see: [Terraform for OCI](https://www.terraform.io/docs/providers/oci/index.html)
+and  more [terraform commands](https://www.terraform.io/docs/commands/index.html)
+
+
+
+

--- a/micronaut-webapp/infrastructure/oci/infrastructure.tf
+++ b/micronaut-webapp/infrastructure/oci/infrastructure.tf
@@ -1,0 +1,208 @@
+// Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "region" {}
+variable "compartment_ocid" {}
+variable "ssh_public_key" {}
+variable "ssh_private_key" {}
+
+provider "oci" {
+  tenancy_ocid     = "${var.tenancy_ocid}"
+  user_ocid        = "${var.user_ocid}"
+  fingerprint      = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region           = "${var.region}"
+}
+
+// TODO: change this to some representative name. Lowercase only no special characters, no more than 5 chars eg: test
+variable "sufix_name" {
+  default = "test"
+}
+
+// TODO: change if +/- instances
+variable "num_instances" {
+  default = "2"
+}
+
+
+variable "instance_shape" {
+  default = "VM.Standard1.2"
+}
+
+variable "instance_image_ocid" {
+  type = "map"
+
+  default = {
+    # See https://docs.us-phoenix-1.oraclecloud.com/images/
+    # Oracle-provided image "Oracle-Linux-7.5-2018.10.16-0"
+    us-phoenix-1 = "ocid1.image.oc1.phx.aaaaaaaaoqj42sokaoh42l76wsyhn3k2beuntrh5maj3gmgmzeyr55zzrwwa"
+    us-ashburn-1   = "ocid1.image.oc1.iad.aaaaaaaageeenzyuxgia726xur4ztaoxbxyjlxogdhreu3ngfj2gji3bayda"
+    eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaaitzn6tdyjer7jl34h2ujz74jwy5nkbukbh55ekp6oyzwrtfa4zma"
+    uk-london-1    = "ocid1.image.oc1.uk-london-1.aaaaaaaa32voyikkkzfxyo4xbdmadc2dmvorfxxgdhpnk6dw64fa3l4jh7wa"
+  }
+}
+
+data "oci_identity_availability_domain" "ad" {
+  compartment_id = "${var.tenancy_ocid}"
+  ad_number      = 1
+}
+
+resource "oci_core_vcn" "graalvm_vcn" {
+  cidr_block     = "10.1.0.0/16"
+  compartment_id = "${var.compartment_ocid}"
+  display_name   = "GraalVMVcn-${var.sufix_name}"
+  dns_label      = "graalvmvcn${var.sufix_name}"
+}
+
+resource "oci_core_security_list" "graalvm_hosts_security_list" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id         = "${oci_core_vcn.graalvm_vcn.id}"
+  display_name   = "GraalvmHostsSecurityLists-${var.sufix_name}"
+
+  // allow outbound tcp traffic on all ports
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+    stateless = false
+  }
+
+  // allow inbound ssh traffic from a specific port
+  ingress_security_rules {
+    protocol  = "6"         // tcp
+    source    = "0.0.0.0/0"
+    stateless = false
+
+    tcp_options {
+      // These values correspond to the destination port range.
+      min = 22
+      max = 22
+    }
+  }
+
+  // allow inbound icmp traffic of a specific type
+  ingress_security_rules {
+    protocol  = 1
+    source    = "0.0.0.0/0"
+    stateless = true
+
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+
+  // allow inbound http traffic on specific ports 8080-8085
+  ingress_security_rules {
+    protocol  = "6"         // tcp
+    source    = "10.1.0.0/16"
+    stateless = false
+
+    tcp_options {
+      // These values correspond to the destination port range.
+      min = 8080
+      max = 8085
+    }
+  }
+
+  // allow inbound http traffic on specific ports 8080-8085
+  ingress_security_rules {
+    protocol  = "6"         // tcp
+    source    = "10.1.0.0/16"
+    stateless = false
+
+    tcp_options {
+      // These values correspond to the destination port range.
+      min = 8443
+      max = 8443
+    }
+  }
+}
+
+resource "oci_core_internet_gateway" "graalvm_internet_gateway" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name   = "GraalVMInternetGateway-${var.sufix_name}"
+  vcn_id         = "${oci_core_vcn.graalvm_vcn.id}"
+}
+
+resource "oci_core_route_table" "graalvm_route_table" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id         = "${oci_core_vcn.graalvm_vcn.id}"
+  display_name   = "GraalVMRouteTable-${var.sufix_name}"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = "${oci_core_internet_gateway.graalvm_internet_gateway.id}"
+  }
+}
+
+resource "oci_core_subnet" "graalvm_subnet" {
+  availability_domain = "${data.oci_identity_availability_domain.ad.name}"
+  cidr_block          = "10.1.20.0/24"
+  display_name        = "graalvmSubnet-${var.sufix_name}"
+  dns_label           = "graalvmsubnet"
+  security_list_ids   = ["${oci_core_security_list.graalvm_hosts_security_list.id}"]
+  compartment_id      = "${var.compartment_ocid}"
+  vcn_id              = "${oci_core_vcn.graalvm_vcn.id}"
+  route_table_id      = "${oci_core_route_table.graalvm_route_table.id}"
+  dhcp_options_id     = "${oci_core_vcn.graalvm_vcn.default_dhcp_options_id}"
+}
+
+
+resource "oci_core_instance" "graalvm_test_instance" {
+  availability_domain = "${data.oci_identity_availability_domain.ad.name}"
+  compartment_id      = "${var.compartment_ocid}"
+  display_name        = "GraalVMHost-${var.sufix_name}"
+  shape               = "${var.instance_shape}"
+  count = "${var.num_instances}"
+
+  create_vnic_details {
+    subnet_id        = "${oci_core_subnet.graalvm_subnet.id}"
+    display_name     = "HostPrimaryVnic-${var.sufix_name}"
+    assign_public_ip = true
+    hostname_label   = "GraalVMHost-${var.sufix_name}-${count.index}"
+  }
+
+  metadata = {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data           = "${base64encode(file("./init.sh"))}"
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = "${var.instance_image_ocid[var.region]}"
+  }
+
+  timeouts {
+    create = "60m"
+  }
+}
+
+resource "null_resource" "remote-exec" {
+  depends_on = ["oci_core_instance.graalvm_test_instance"]
+  count = "${var.num_instances}"
+
+  provisioner "remote-exec" {
+    connection {
+      agent = false
+      timeout = "30m"
+      host = "${oci_core_instance.graalvm_test_instance.*.public_ip[count.index % var.num_instances]}"
+      user = "opc"
+      private_key = "${var.ssh_private_key}"
+    }
+
+    script = "provision.sh"
+  }
+}
+
+output "instance_private_ips" {
+  value = ["${oci_core_instance.graalvm_test_instance.*.private_ip}"]
+}
+
+output "instance_public_ips" {
+  value = ["${oci_core_instance.graalvm_test_instance.*.public_ip}"]
+}
+

--- a/micronaut-webapp/infrastructure/oci/init.sh
+++ b/micronaut-webapp/infrastructure/oci/init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#Create a docker user and add the opc user to it
+#This will allow us to call docker commands without sudo
+groupadd docker
+usermod -aG docker opc
+
+#Install docker
+yum install -y docker-engine
+systemctl start docker
+systemctl enable docker
+

--- a/micronaut-webapp/infrastructure/oci/provision.sh
+++ b/micronaut-webapp/infrastructure/oci/provision.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#Open ports for the services to communicate
+sudo firewall-cmd --zone=public --permanent --add-port=8080-8085/tcp
+sudo firewall-cmd --zone=public --permanent --add-port=8443/tcp
+sudo firewall-cmd --reload
+
+
+


### PR DESCRIPTION
All this adds scripts to manage infrastructure to deploy the services.
It does so via `Terraform`.  The `README` file has information on how to use the script. 

This scripts can also be used when preparing hosts for a demo or a presentation (provided that you have the right credentials)