### PR TITLE
Use idiomatic Kotlin in the demo

### DIFF
--- a/java-kotlin-aot/src/main/kotlin/hello/KotlinHello.kt
+++ b/java-kotlin-aot/src/main/kotlin/hello/KotlinHello.kt
@@ -3,5 +3,5 @@ package hello
 val KotlinHelloString : String = "Hello from Kotlin!"
 
 fun getHelloStringFromJava() : String {
-    return JavaHello.JavaHelloString!!;
+    return JavaHello.JavaHelloString
 }


### PR DESCRIPTION
Remove the unnecessary semicolon and double-bang operator, as Kotlin compiler inserts its own check for null.

This way the implementation is looks more idiomatic in Kotlin