### PR TITLE
Upgrade Kotlin to 1.5.30

### DIFF
--- a/java-kotlin-aot/pom.xml
+++ b/java-kotlin-aot/pom.xml
@@ -10,7 +10,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>1.5.21</kotlin.version>
+        <kotlin.version>1.5.30</kotlin.version>
         <junit.version>4.12</junit.version>
         <main.class>kotlin.KotlinHelloKt</main.class>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/java-kotlin-aot/pom.xml
+++ b/java-kotlin-aot/pom.xml
@@ -10,7 +10,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin.version>1.5.21</kotlin.version>
         <junit.version>4.12</junit.version>
         <main.class>kotlin.KotlinHelloKt</main.class>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -92,6 +92,10 @@
                         <goals> <goal>testCompile</goal> </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As Kotlin 1.3 is being deprecated by JetBrains, let's upgrade it to the modern version.

I've also pinned Java version so that IDEs have easier time configuring themselves, when opening a project.