### PR TITLE
Enabled building containers and running examples/demos on the cloud (OCI)

### DIFF
--- a/deployments/oci/.gitignore
+++ b/deployments/oci/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+*.rc
+*.tfstate*

--- a/deployments/oci/README.md
+++ b/deployments/oci/README.md
@@ -1,0 +1,181 @@
+# Deployment: Infrastructure as code
+
+The scripts in this folder give the ability to provision and manage compute capacity using [Oracle Cloud Infrastructure](https://docs.cloud.oracle.com/iaas/Content/services.htm), in
+order to deploy the docker container and run the GraalVM demos in it. 
+
+In short the scripts does the below:
+- create computes instances and associated 
+network resources necessary to run an instance on OCI
+- creates a virtual network with a subnet and puts one host on this subnet
+- adds the necessary permissions to allow services to communicate in the subnet within specific ports (egress and ingress rules)
+- runs the `init.sh` script to install basic tool(s) on the hosts 
+- finally, the `provision.sh` script to prepare the instance ready to be used -- by triggering the docker container to stand up the Jupyter labs server
+- also provides the necessary help in the form of ready-to-use shell-scripts toto perform various tasks with the help of `terraform` and `ssh`
+
+**Table of content**
+- [Pre-requisites](#pre-requisites)
+- [Provisioning Infrastructure using Terraform](#provisioning-infrastructure-using-terraform)
+  + [Setting up credentials](#setting-up-credentials)
+  + [Create infrastructure from the CLI using Terraform](#create-infrastructure-from-the-cli-using-terraform)
+  + [Deploy the docker image in the cloud](#deploy-the-docker-image-in-the-cloud)
+  + [Recover/retry from failed attempt](#recoverretry-from-failed-attempt)
+  + [Start clean after a failed attempt (errors encountered)](#start-clean-after-a-failed-attempt-errors-encountered)
+  + [Destroy infrastructure (cleanup)](#destroy-infrastructure-cleanup)
+- [Security](#security)
+- [OCI and Terraform resources](#oci-and-terraform-resources)
+
+## Pre-requisites
+
+- **A [Oracle Cloud (OCI)](https://www.oracle.com/cloud/free/) Account (you maybe able to procure some FREE credits via the [Oracle Cloud Free Tier](https://www.oracle.com/cloud/free/) program)**
+- A properly configured [Oracle Cloud Infrastructure account](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm). See [Ensure OCI account is created and you can log in](https://docs.oracle.com/en-us/iaas/Content/General/Reference/PaaSprereqs.htm)
+Note: the above step is one-off, you won't need to do this everything we run instances on the Oracle Cloud. But do ensure the minimum prerequisites are fulfilled.
+- [Install Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) (all methods for the various platforms are mentioned)
+- Clone this repo and in the right folder:
+```bash
+$ git clone https://github.com/graalvm/graalvm-demos
+$ cd deployments/oci
+```
+- Create your credentials file (one-off, you can reuse this for future purposes) in the `examples/tribuo/deployments/oci` folder. Use the `credentials.rc_template` to create your own credentials file for your OCI account. The file should look like the below (as per the `credentials.rc_template` file provided):
+
+```bash
+### Terraform env variables
+export TF_VAR_tenancy_ocid=[TENANCY_OCID]
+export TF_VAR_compartment_ocid=[COMPARMENT_OCID]
+export TF_VAR_user_ocid=[USER_OCID]
+export TF_VAR_fingerprint=[FINGERPRINT]
+export TF_VAR_private_key_path=[PATH_TO_YOUR_ACCOUNT_PRIVATE_KEY eg: ~/.oci/key.pem]
+export TF_VAR_region=[REGION NAME eg: uk-london-1]
+
+### ssh keys that will be used for remote access authenication
+export TF_VAR_ssh_public_key="$(cat [PATH_TO_SSH_PUBLIC_KEY])"
+
+## We won't be assigning the private_key contents into an environment variable but pass it as an argument via the CLI
+echo 'Pass -var "ssh_private_key=$(cat [PATH_TO_YOUR_SSH_PRIVATE_KEY])" when running the "terraform apply" or "terraform destory" commands'
+```
+Note the `TF_VAR` prefix, as it is a terraform convention for input variables. 
+
+Here is a list of resources on where to look for each of the above resources:
+
+- [Refer to this link](https://cloud.oracle.com/tenancy)  to find out about `[TENANCY_OCID]` (look for the **OCID** field under the Tenancy Information on the page)
+- Use the left-hand [Navigation menu > Identity > Compartments](https://cloud.oracle.com/identity/compartments), select the compartment to find out about `[COMPARMENT_OCID]` where you should look for the **OCID** field
+- Go to `Profile Icon` > `User Settings` or left-hand [Navigation menu > Identity > Users](https://cloud.oracle.com/identity/users) > Select the user from the list (yourself), look for the **OCID** field to find out about `[USER_OCID]`
+- Go to [Navigation menu > Identity > Users](https://cloud.oracle.com/identity/users) > Select the user from the list (yourself), then from under **Resource**, click on **API Keys > Add API Key**. Here you can choose to either generate a new key-pair or use an existing one (choose the Public key file or paste it's content), once done, you are shown the finger print for the `[TF_VAR_fingerprint]` variable
+- And depending on the above choice, make sure you note the location of the Private key of the key-pair from the above selection, this is needed for `[TF_VAR_private_key_path]`
+Other resources [1](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five) | [2](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two) | [3](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#four) | [4](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five) (look for How to Upload the Public Key)
+- Refer to [Regions page](https://cloud.oracle.com/regions/infrastructure) to look for the Region Identifier that is relevant to your account for the `[TF_VAR_region]` field
+- `[TF_VAR_ssh_public_key]` and `[TF_VAR_ssh_private_key]` are already known to you, they are referring to the contents of the keys in `~/.ssh/id_rsa.pub` and `~/.ssh/id_rsa` files respectively.
+
+For a summary (also helps to verify the steps) of the above steps please see [here](https://www.terraform.io/docs/providers/oci/index.html).
+
+## Provisioning Infrastructure using Terraform
+
+### Setting up credentials
+
+- Source your credentials file
+
+```bash
+$ source credentials.rc
+```
+
+### Create infrastructure from the CLI using Terraform
+
+- Deploy with terraform
+
+```bash
+$ terraform init
+$ terraform apply -var "ssh_private_key=$(cat ~/.ssh/id_rsa)" --auto-approve
+```
+
+The deployment process should end with a list of private/public ip addresses like so:
+
+```bash
+Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+instance_private_ips = [
+    10.1.nn.m
+]
+instance_public_ips = [
+    1xx.145.174.85
+]
+
+```
+
+The public IP addresses are fairly dynamic in nature and could be between any range (example shown above). Please make a note of the Public IP above as it will be needed in the following steps.
+
+### Deploy the docker image in the cloud
+
+- use ssh and docker to make that end meet
+
+```bash
+$ ./run-docker-container-in-the-cloud.sh
+```
+
+An alternative way to find out the Public IP(s) of the created resources are:
+
+```bash
+$ ./get-instance-public-ip.sh
+```
+
+### Recover/retry from failed attempt
+
+- Apply the fix to the configuration or script or both
+- And run the below again:
+
+```bash
+$ terraform apply -var "ssh_private_key=$(cat ~/.ssh/id_rsa)" --auto-approve
+```
+
+### Start clean after a failed attempt (errors encountered)
+
+- Run the below before proceeding:
+
+```bash
+$ terraform destroy -var "ssh_private_key=$(cat ~/.ssh/id_rsa)" --auto-approve
+$ terraform apply -var "ssh_private_key=$(cat ~/.ssh/id_rsa)" --auto-approve
+```
+
+This is particularly important on OCI when one or more resources did not get created and before trying again we should clean-up or else Terraform may try to recreate an already existing (invalid instance) resource and you could get errors like "Service rate limit exceeded".
+
+### Destroy infrastructure (cleanup)
+
+- Remove resources or destroy them with terraform
+
+```bash
+$ terraform destroy -var "ssh_private_key=$(cat ~/.ssh/id_rsa)" --auto-approve
+```
+
+You should see something like this at the end of a successful run:
+
+```text
+.
+.
+.
+Destroy complete! Resources: 7 destroyed.
+```
+
+### Security
+
+Note that this setup does not take into account establishing a secure `http` i.e. `https` communication between VM/Docker instances and the browser. Please beware when using this in your target domain depending on the prerequisites you need to conform to. This example is good for learning and illustration purposes, please do NOT deploy it in production or public facing environments. The current instance is for learning, illustration and demonstration purposes only.
+
+### OCI and Terraform resources
+
+- For more information on Terraform infrastructure management see: [Terraform for OCI](https://www.terraform.io/docs/providers/oci/index.html)
+- [Terraform commands](https://www.terraform.io/docs/commands/index.html)
+- [See working example using Micronaut running on GraalVM](https://github.com/graalvm/graalvm-demos/tree/master/micronaut-webapp/deployments/oci)
+- [Ensure OCI account is created and you can log in](https://docs.oracle.com/en-us/iaas/Content/General/Reference/PaaSprereqs.htm) 
+- Install OCI cli command tool (or use a language specific SDK) -- one-off task]
+  - https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdks.htm#Software_Development_Kits_and_Command_Line_Interface
+    - [Download CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm#Quickstart)
+    + Setting up the Config File 
+        + [Where to Get the Tenancy's OCID and User's OCID](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five)
+        + [Regions and Availability Domains](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm#top)
+        + [SDK and CLI configuratuon File](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm)
+- How to find values of the Terraform OCI related variables
+    - [Oracle Cloud Infrastructure account](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm)
+- [What are Compartments?](https://cloud.oracle.com/identity/compartments)
+
+---
+
+Go to [GraalVM Demos Main page](../../README.md)

--- a/deployments/oci/credentials.rc_template
+++ b/deployments/oci/credentials.rc_template
@@ -1,0 +1,30 @@
+## Terraform env variables
+
+# Read about the concepts
+# https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five
+
+# Refer to these links before find out
+# https://cloud.oracle.com/tenancy (Look for Tenancy Information) 
+export TF_VAR_tenancy_ocid=[TENANCY_OCID]
+
+# Go to https://cloud.oracle.com/identity/compartments/ocid1.compartment.oc1..[some-hash] to find out
+export TF_VAR_compartment_ocid=[COMPARMENT_OCID]
+
+# Go to https://cloud.oracle.com/identity/users/ocid1.user.oc1..[some-hash] to find out
+export TF_VAR_user_ocid=[USER_OCID]
+
+# https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two
+# https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#four
+# https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five (look for How to Upload the Public Key)
+# OCI Web Interface: Governance > Identity > API Keys > Add API Key > [select one of the options]
+export TF_VAR_fingerprint=[FINGERPRINT]
+export TF_VAR_private_key_path=[PATH_TO_YOUR_ACCOUNT_PRIVATE_KEY eg: ~/.oci/key.pem]
+
+# Refer to https://cloud.oracle.com/regions/infrastructure to look for the Region Identifier that is relevant to your account
+export TF_VAR_region=[REGION NAME eg: uk-london-1]
+
+## ssh keys that will be used for remote access authenication
+export TF_VAR_ssh_public_key="$(cat [PATH_TO_YOUR_SSH_PUBLIC_KEY])"
+
+## We won't be assigning the private_key contents into an environment variable but pass it as an argument via the CLI
+echo 'Pass -var "ssh_private_key=$(cat [PATH_TO_YOUR_SSH_PRIVATE_KEY])" when running the "terraform apply" or "terraform destory" commands'

--- a/deployments/oci/get-instance-public-ip.sh
+++ b/deployments/oci/get-instance-public-ip.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+terraform output instance_public_ips \
+          | grep "\." | head -n 1 | tr -d '" ,'

--- a/deployments/oci/infrastructure.tf
+++ b/deployments/oci/infrastructure.tf
@@ -1,0 +1,209 @@
+// Credits: https://github.com/graalvm/graalvm-demos/tree/master/micronaut-webapp/
+// Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+// The Universal Permissive License (UPL), Version 1.0
+
+variable "tenancy_ocid" {}
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+variable "region" {}
+variable "compartment_ocid" {}
+variable "ssh_public_key" {}
+variable "ssh_private_key" {}
+
+// Keep number of characters to minimum (3 to 5 chars max)
+// `project_code` is used as prefix to `xxx_label` variables
+// Terraform & OCI conventions mean they should be under 15 characters
+variable "project_code" {
+  //default = "gvm-demos"
+  default = "demos"
+}
+
+// `project_name` is used as prefix to `display_name` variables
+// Can be long, but must follow Terraform & OCI conventions
+variable "project_name" {
+  //default = "GVMDemos-OCI-TF"
+  default = "Demos-OCI-TF"
+}
+
+variable "suffix_name" {
+  default = "public"
+}
+
+variable "num_instances" {
+  default = "1"
+}
+
+// https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm#vmshapes
+variable "instance_shape" {
+  default = "VM.Standard2.1"
+}
+
+variable "instance_image_ocid" {
+  type = map(string)
+
+  default = {
+    # See https://docs.us-phoenix-1.oraclecloud.com/images/
+    # Oracle-provided image "Oracle-Linux-7.5-2018.10.16-0"
+    us-phoenix-1 = "ocid1.image.oc1.phx.aaaaaaaaoqj42sokaoh42l76wsyhn3k2beuntrh5maj3gmgmzeyr55zzrwwa"
+    us-ashburn-1   = "ocid1.image.oc1.iad.aaaaaaaageeenzyuxgia726xur4ztaoxbxyjlxogdhreu3ngfj2gji3bayda"
+    eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaaitzn6tdyjer7jl34h2ujz74jwy5nkbukbh55ekp6oyzwrtfa4zma"
+    uk-london-1    = "ocid1.image.oc1.uk-london-1.aaaaaaaa32voyikkkzfxyo4xbdmadc2dmvorfxxgdhpnk6dw64fa3l4jh7wa"
+  }
+}
+
+provider "oci" {
+  tenancy_ocid     = "${var.tenancy_ocid}"
+  user_ocid        = "${var.user_ocid}"
+  fingerprint      = "${var.fingerprint}"
+  private_key_path = "${var.private_key_path}"
+  region           = "${var.region}"
+}
+
+data "oci_identity_availability_domain" "ad" {
+  compartment_id = "${var.tenancy_ocid}"
+  ad_number      = 1
+}
+
+resource "oci_core_vcn" "ocivcn" {
+  cidr_block     = "10.1.0.0/16"
+  compartment_id = "${var.compartment_ocid}"
+  display_name   = "${var.project_name}-Vcn-${var.suffix_name}"
+  dns_label      = "${var.project_code}vcn${var.suffix_name}"
+}
+
+resource "oci_core_security_list" "oci_hosts_security_list" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id         = "${oci_core_vcn.ocivcn.id}"
+  display_name   = "${var.project_name}-HostsSecurityLists-${var.suffix_name}"
+
+  // allow outbound tcp traffic on all ports
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+    stateless = false
+  }
+
+  // allow inbound ssh traffic from a specific port
+  ingress_security_rules {
+    protocol  = "6"         // tcp
+    source    = "0.0.0.0/0"
+    stateless = false
+
+    tcp_options {
+      // These values correspond to the destination port range.
+      min = 22
+      max = 22
+    }
+  }
+
+  // allow inbound icmp traffic of a specific type
+  ingress_security_rules {
+    protocol  = 1
+    source    = "0.0.0.0/0"
+    stateless = true
+
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+
+  // allow inbound http traffic on specific ports 8888
+  ingress_security_rules {
+    protocol  = "6"         // tcp
+    source    = "0.0.0.0/0"
+    stateless = false
+
+    tcp_options {
+      // These values correspond to the destination port range.
+      min = 8888
+      max = 8888
+    }
+  }
+}
+
+resource "oci_core_internet_gateway" "oci_internet_gateway" {
+  compartment_id = "${var.compartment_ocid}"
+  display_name   = "${var.project_name}-InternetGateway-${var.suffix_name}"
+  vcn_id         = "${oci_core_vcn.ocivcn.id}"
+}
+
+resource "oci_core_route_table" "oci_route_table" {
+  compartment_id = "${var.compartment_ocid}"
+  vcn_id         = "${oci_core_vcn.ocivcn.id}"
+  display_name   = "${var.project_name}-RouteTable-${var.suffix_name}"
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = "${oci_core_internet_gateway.oci_internet_gateway.id}"
+  }
+}
+
+resource "oci_core_subnet" "oci_subnet" {
+  availability_domain = "${data.oci_identity_availability_domain.ad.name}"
+  cidr_block          = "10.1.20.0/24"
+  display_name        = "${var.project_name}-Subnet-${var.suffix_name}"
+  dns_label           = "${var.project_code}subnet"
+  security_list_ids   = ["${oci_core_security_list.oci_hosts_security_list.id}"]
+  compartment_id      = "${var.compartment_ocid}"
+  vcn_id              = "${oci_core_vcn.ocivcn.id}"
+  route_table_id      = "${oci_core_route_table.oci_route_table.id}"
+  dhcp_options_id     = "${oci_core_vcn.ocivcn.default_dhcp_options_id}"
+}
+
+
+resource "oci_core_instance" "oci_oci_instance" {
+  availability_domain = "${data.oci_identity_availability_domain.ad.name}"
+  compartment_id      = "${var.compartment_ocid}"
+  display_name        = "${var.project_name}-Host-${var.suffix_name}"
+  shape               = "${var.instance_shape}"
+  count = "${var.num_instances}"
+
+  create_vnic_details {
+    subnet_id        = "${oci_core_subnet.oci_subnet.id}"
+    display_name     = "HostPrimaryVnic-${var.suffix_name}"
+    assign_public_ip = true
+    hostname_label   = "${var.project_name}-Host-${var.suffix_name}-${count.index}"
+  }
+
+  metadata = {
+    ssh_authorized_keys = "${var.ssh_public_key}"
+    user_data           = "${base64encode(file("./init.sh"))}"
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = "${var.instance_image_ocid[var.region]}"
+  }
+
+  timeouts {
+    create = "60m"
+  }
+}
+
+resource "null_resource" "remote-exec" {
+  depends_on = [oci_core_instance.oci_oci_instance]
+  count = "${var.num_instances}"
+
+  provisioner "remote-exec" {
+    connection {
+      agent = false
+      timeout = "30m"
+      host = "${oci_core_instance.oci_oci_instance.*.public_ip[count.index % var.num_instances]}"
+      user = "opc"
+      private_key = "${var.ssh_private_key}"
+    }
+
+    script = "provision.sh"
+  }
+}
+
+output "instance_private_ips" {
+  value = ["${oci_core_instance.oci_oci_instance.*.private_ip}"]
+}
+
+output "instance_public_ips" {
+  value = ["${oci_core_instance.oci_oci_instance.*.public_ip}"]
+}

--- a/deployments/oci/infrastructure.tf
+++ b/deployments/oci/infrastructure.tf
@@ -15,15 +15,13 @@ variable "ssh_private_key" {}
 // `project_code` is used as prefix to `xxx_label` variables
 // Terraform & OCI conventions mean they should be under 15 characters
 variable "project_code" {
-  //default = "gvm-demos"
   default = "demos"
 }
 
 // `project_name` is used as prefix to `display_name` variables
 // Can be long, but must follow Terraform & OCI conventions
 variable "project_name" {
-  //default = "GVMDemos-OCI-TF"
-  default = "Demos-OCI-TF"
+  default = "GVMDemos-OCI"
 }
 
 variable "suffix_name" {

--- a/deployments/oci/init.sh
+++ b/deployments/oci/init.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Create a docker user and add the opc user to it
+# This will allow us to call docker commands without sudo
+groupadd docker
+usermod -aG docker opc
+
+# Install docker
+yum install -y docker-engine
+systemctl start docker
+systemctl enable docker

--- a/deployments/oci/provision.sh
+++ b/deployments/oci/provision.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+sudo yum install -y git
+
+# Open ports for the services to communicate
+sudo firewall-cmd --zone=public --permanent --add-port=8080-8085/tcp
+sudo firewall-cmd --zone=public --permanent --add-port=8443/tcp
+sudo firewall-cmd --reload
+
+#git clone https://github.com/graalvm/graalvm-demos
+git clone https://github.com/neomatrix369/graalvm-demos
+cd graalvm-demos
+git checkout provide-Docker-scripts
+cd docker-images/ && ./buildDockerImage.sh
+
+echo "|-----------------------------------------------------------------------------------------------------|"
+echo "|                                                                                                     |"
+echo "| ssh onto the OCI box followed by the below command:                                                 |"
+echo "|                                                                                                     |"
+echo "|       $ ./run-docker-container-in-the-cloud.sh                                                      |"
+echo "|                                                                                                     |"
+echo "|-----------------------------------------------------------------------------------------------------|"

--- a/deployments/oci/provision.sh
+++ b/deployments/oci/provision.sh
@@ -7,16 +7,37 @@ sudo firewall-cmd --zone=public --permanent --add-port=8080-8085/tcp
 sudo firewall-cmd --zone=public --permanent --add-port=8443/tcp
 sudo firewall-cmd --reload
 
-#git clone https://github.com/graalvm/graalvm-demos
-git clone https://github.com/neomatrix369/graalvm-demos
+git clone https://github.com/graalvm/graalvm-demos
 cd graalvm-demos
-git checkout provide-Docker-scripts
-cd docker-images/ && ./buildDockerImage.sh
+git checkout master
+
+echo "|-------------------------------------------------------------------------------------------------------|"
+echo "|                                                                                                       |"
+echo "| ssh onto the OCI box followed by the below command:                                                   |"
+echo "|                                                                                                       |"
+echo "|     $ ./run-docker-container-in-the-cloud.sh [CLI ARGS IN DOUBLE QUOTES]                              |"
+echo "|                                                                                                       |"
+echo "|     [CLI ARGS IN DOUBLE QUOTES] - (optional) can be shell commands or build/run                       |"
+echo "|                                   shellscript name and parameter                                      |"
+echo "|     No args will give the shell-prompt to allow running the same shell commands                       |"
+echo "|                                                                                                       |"
+echo "| for e.g.                                                                                              |"
+echo "|     $ ./run-docker-container-in-the-cloud.sh                                                          |"
+echo "|                                                                                                       |"
+echo "|                                       or                                                              |"
+echo "|                                                                                                       |"
+echo "|     $ ./run-docker-container-in-the-cloud.sh \"cd graalvm-demos; ./buildDockerImage.sh java11-21.2.0\"|"
+echo "|                                                                                                       |"
+echo "|        see https://github.com/graalvm/graalvm-demos#graalvm-demos for more examples                   |"
+echo "|                                                                                                       |"
+echo "|-------------------------------------------------------------------------------------------------------|"
+
 
 echo "|-----------------------------------------------------------------------------------------------------|"
 echo "|                                                                                                     |"
-echo "| ssh onto the OCI box followed by the below command:                                                 |"
+echo "|     Once in the box you can run the build or run shellscripts from your local machine,              |"
+echo "|     via the command-line interface (CLI). The steps are mentioned on the README page:               |"
 echo "|                                                                                                     |"
-echo "|       $ ./run-docker-container-in-the-cloud.sh                                                      |"
+echo "|                https://github.com/graalvm/graalvm-demos#graalvm-demos                               |"
 echo "|                                                                                                     |"
 echo "|-----------------------------------------------------------------------------------------------------|"

--- a/deployments/oci/run-docker-container-in-the-cloud.sh
+++ b/deployments/oci/run-docker-container-in-the-cloud.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+INSTANCE_PUBLIC_IP="$(get-instance-public-ip.sh)"
+
+echo "Public IP address of the cloud instance running is ${INSTANCE_PUBLIC_IP}"
+
+exit_code=0
+ssh opc@${INSTANCE_PUBLIC_IP} \
+    'cd graalvm-demos; git checkout provide-Docker-scripts; ./runDockerImage.sh' \
+    || exit_code=$? && true
+
+if [[ ${exit_code} -eq 0 ]]; then
+	echo ""
+	echo "Finished loading up the docker container in the cloud instance."
+	echo ""
+else
+	echo ""
+	echo "Failed trying to run the docker container, its possible it has already been executed, check the error logs above."
+	echo "Or try to ssh into the container and investigate."
+	echo ""
+fi
+
+echo "If the container has run successfully (without any errors in the console), then you can ssh into it to gain access to the docker instance."

--- a/deployments/oci/run-docker-container-in-the-cloud.sh
+++ b/deployments/oci/run-docker-container-in-the-cloud.sh
@@ -7,9 +7,9 @@ INSTANCE_PUBLIC_IP="$(get-instance-public-ip.sh)"
 
 echo "Public IP address of the cloud instance running is ${INSTANCE_PUBLIC_IP}"
 
+ANY_CLI_ARGS="$@"
 exit_code=0
-ssh opc@${INSTANCE_PUBLIC_IP} \
-    'cd graalvm-demos; git checkout provide-Docker-scripts; ./runDockerImage.sh' \
+ssh opc@${INSTANCE_PUBLIC_IP} "${ANY_CLI_ARGS}" \
     || exit_code=$? && true
 
 if [[ ${exit_code} -eq 0 ]]; then

--- a/javagdbnative/README.MD
+++ b/javagdbnative/README.MD
@@ -1,0 +1,34 @@
+# Native Image Debugging from Java Source Code
+
+This demo is intended to be used to demonstrate how to debug a Java application, built into a native executable, using [GraalVM VS Code Extension Pack for Java](https://marketplace.visualstudio.com/items?itemName=oracle-labs-graalvm.graalvm-pack).
+
+## Prerequisities
+1. Linux OS with GDB 10.1
+2. Visual Studio Code
+3. GraalVM Extension Pack for Java: Open Visual Studio Code, navigate to Extensions activity panel in the left-hand side Activity Bar (or use the Ctrl+Shift+X hot keys combination). Search for “GraalVM” in the search field. Find "GraalVM Extension Pack for Java", press Install. Reload will be required.
+4. [GraalVM](https://www.graalvm.org/downloads) runtime environment: Navigate to Gr activity panel in VS Code and install some of the latest GraalVM __Enterprise Edition__ versions available from the list.
+5. [Native Image](https://www.graalvm.org/reference-manual/native-image/): Upon GraalVM's installation completion, the “Install Optional GraalVM Components” window pops up in the right bottom corner. Install Native Image.
+
+## Building the Sample
+1. Clone Download or clone the GraalVM Demos repository:
+```git clone https://github.com/graalvm/graalvm-demos```
+2. Open the demo folder, _graalvm/demos/javagdbnative_, in VS Code.
+3. Open VS Code Terminal window and run following command:
+
+```mvn -Pnative -DskipTests package```
+
+The ```mvn -Pnative -DskipTests package``` command will package a Java application into a runnable JAR file, and then build a native executable of it.
+
+## Debugging the Sample
+1. Select Run and Debug activity panel in VSCode
+2. Add a new launch configuration named ```Native Image: launch``` into launch.json which should look like this:
+```
+{
+    "type": "nativeimage",
+    "request": "launch",
+    "name": "Launch Native Image",
+    "nativeImagePath": "${workspaceFolder}/target/javagdb",
+    "args": "100"
+}
+```
+3. Then run debugger using ```Launch Native Image``` from RUN ... menu. It will start debugging a native image binary in VSCode using Java source code.        

--- a/javagdbnative/pom.xml
+++ b/javagdbnative/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>javagdb</groupId>
+  <artifactId>javagdbnative</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>javagdbnative</name>
+  <!-- FIXME change it to the project's website -->
+  <url>https://github.com/graalvm/graalvm-demos</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  
+  <profiles>
+    <profile>
+      <id>native</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.9.7</version> <!-- or newer version -->
+            <executions>
+              <execution>
+                <id>test-native</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>test</phase>
+              </execution>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <imageName>javagdb</imageName>
+              <mainClass>javagdb.App</mainClass>
+              <buildArgs>
+              --no-fallback
+              --verbose
+                <buildArg>-g</buildArg>
+                <buildArg>-O0</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+</profiles>
+</project>

--- a/javagdbnative/src/main/java/javagdb/App.java
+++ b/javagdbnative/src/main/java/javagdb/App.java
@@ -1,0 +1,50 @@
+package javagdb;
+
+
+public class App 
+{
+    static long fieldUsed = 1000;
+
+    public static void main( String[] args )
+    {
+        if (args.length > 0){
+            int n = -1;
+            try {
+                n = Integer.parseInt(args[0]);
+            } catch (NumberFormatException ex) {
+                System.out.println(args[0] + " is not a number!");
+            }
+            if (n < 0) {
+                System.out.println(args[0] + " is negative.");
+            }
+            double f = factorial(n);
+            System.out.println(n + "! = " + f);
+        } 
+
+        if (false)
+            neverCalledMethod();
+
+        StringBuilder text = new StringBuilder();
+        text.append("Hello World from GraalVM native image and GDB in Java.\n");
+        text.append("Native image debugging made easy!");
+        System.out.println(text.toString());
+    }
+
+    static void neverCalledMethod(){
+        System.out.println("This method will be never called and taken of by native-image.");
+    }
+
+    static double factorial(int n) {
+        if (n == 0) {
+            return 1;
+        }
+        if (n >= fieldUsed) {
+            return Double.POSITIVE_INFINITY;
+        }
+        double f = 1;
+        while (n > 1) {
+            f *= n--;
+        }
+        return f;
+    }
+}

--- a/native-image-workshop/README.md
+++ b/native-image-workshop/README.md
@@ -10,31 +10,35 @@
 We are going to use a fairly trivial application to walk through using GraalVM Native Image. Along the way we will see:
 
 1. How you can turn a Java app into a native executable
-2. How you can build a GraalVM Native IMage that works with the dynamic parts of Jva
+2. How you can build a native image that works with the dynamic parts of Java
 3. Using the command line tools for generating a native image, as well as using the Maven tooling
 
 So what is going to be our testbed application? We will use a command line Java application that counts the number of files within the current directory and sub directories. As a nice extra it also calculates their total size.
 
 As you work through this workshop you will need to update the code, in the following steps.
 
-This workshop relies on using GraalVM 21.3 or higher, with the GraalVM Native Image package installed. It will work with either Community Edition (CE), or Enterprise Edition (EE). If there is any EE speific code / configuration, this will be clearly marked out.
+This workshop relies on using GraalVM 21.3 or higher, with GraalVM Native Image installed. It will work with either Community Edition (CE), or Enterprise Edition (EE). If there is any EE speific code / configuration, this will be clearly marked out.
 
 Let's beign!
 
 ## Setup
 
-Install GraalVM. Instructions can be found [here](https://www.graalvm.org/docs/getting-started/.
+Install GraalVM. Instructions can be found on the website:
+
+[Linux](https://www.graalvm.org/docs/getting-started/linux/)
+[macOS](https://www.graalvm.org/docs/getting-started/macos/)
+[Windows](https://www.graalvm.org/docs/getting-started/windows/)
 
 You will need the following installed:
 
-* GraalVM 21.3.0 JDK 11 or JDK17 installed (either EE or CE)
+* GraalVM 21.3.0 JDK 11 or JDK17 installed (either Enterprise Edition or Community Edition)
 * Native Image plugin that matches your GraalVM installation
 
 ## Quick Note on Using Maven Profiles
 
 This workshop will use Maven profiles. Proflies are a great way to have different build configurtions within a single `pom.xml` file. You can find out more about them [here](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
 
-We will use several profiles throughout the project, each of which will serve a different purpose. We are able to call these profiles by passing a parameter containing the name of the profile to maven. The example below shows how we would call the `JAVA` profile, when building with maven:
+We will use several profiles throughout the project, each of which will serve a different purpose. We are able to call these profiles by passing a parameter containing the name of the profile to `mvn`. The example below shows how we would call the `JAVA` profile, when building with maven:
 
 ![User Input](./images/userinput.png)
 ```sh
@@ -43,17 +47,17 @@ $ mvn clean package -PJAVA
 
 The name of the profile to be called is appended to the `-P` flag. We use these profiles within this workshop (all defined in the `pom.xml` file):
 
-1. `java_agent` : Ths builds the Java application with the tracing agent
-2. `native` : This builds the native image
+1. `java_agent` : This builds the Java application with the tracing agent. The agent tracks all usages of dynamic features of your application and captures this inforamtion into configuration files
+2. `native` : This builds the native executable
 
 ## The Java App
 
 The Java application can be found in the `src` directory and it consists of two files. 
 
-* `App.java` : A wrapper for  the `ListDir` application
-* `ListDir.java` : This does all the work, counting the files an summarising the output
+* `App.java` : A wrapper for the `ListDir` application
+* `ListDir.java` : This does all the work, counting the files and summarising the output
 
-We build our application using a maven, `pom.xml` file. Now we have had a basic understanding of our application, let's build our application and see how it works.
+We build our application using a maven, `pom.xml` file. Now we have a basic understanding of our application, let's build our application and see how it works.
 
 ## Build the Basic Java App
 
@@ -86,9 +90,9 @@ Did it work for you?
 
 ## Build a Native Image from the App
 
-Next, you are going to build a native image version of the application. This will start quicker than the Java application.
+Next, we are going to build a native image version of the application. This will start quicker than the Java application.
 
-We will do this by hand first, using the `native-image` tool.. To begin, check that you have a compiled uber JAR in your `target` dir:
+We will do this by hand first, using the `native-image` tool. To begin, check that you have a compiled uber JAR in your `target` dir:
 
 ![User Input](./images/userinput.png)
 ```sh
@@ -104,7 +108,7 @@ $ ls ./target
 
 The file you will need is, `graalvmnidemos-1.0-SNAPSHOT-jar-with-dependencies.jar`.
 
-**NOTE** : You will need to have installed the GraalVM Native Image package for GraalVM - see the set up instructions.
+**NOTE** : You need to have Native Image plugin installed in GraalVM - see the set up instructions.
 
 Now you can generate a native image as follows, within the root of the project:
 
@@ -134,9 +138,9 @@ Compare that to the time running the app with the regular `java` command:
 time java -cp ./target/graalvmnidemos-1.0-SNAPSHOT-jar-with-dependencies.jar oracle.App
 ```
 
-What do the various parameters we passed to the `native-image` command do? Full documentation on these can be found [here](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/):
+What do the various parameters we passed to the `native-image` command do? The full documentation on these can be found [here](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/):
 
-* `--no-fallback`: Do not generate a fallback image. A fallback image requires the JVM to run, and we do not want this.We just want it to be a native image.
+* `--no-fallback`: Do not generate a fallback image. A fallback image requires the JVM to run, and we do not want this. We just want it to be a native image.
 * `-H:Class`: Tell the `native-image` builder which class is the entry point method (the `main` method).
 * `-H:Name`: Specify what the output executable file should be called.
 
@@ -165,9 +169,9 @@ We can also run the `native-image` tool using Maven. If you look at the `pom.xml
         <imageName>${exe.file.name}</imageName>
         <mainClass>${app.main.class}</mainClass>
         <buildArgs>
-            <!-- Don't create a antive exe that falls back to starting a JVM if the image won't build -->
+            <!-- Don't create a native executable that falls back to starting a JVM if the image won't build -->
             <buildArg>--no-fallback</buildArg>
-            <!-- Warn about features that arent supported by native image at the runtime of the image.
+            <!-- Warn about features that arent supported by native image at run time.
                 If there is any reflection, for example, this will generate an error at the runtime of
                 native image.
             -->
@@ -203,7 +207,7 @@ We've already added it as a dependency in the `pom.xml` file, and it can be seen
 </dependency>
 ```
 
-To add `log4j` all we need to do is to open up the `ListDir.java` file and uncomment some things in order to start using it. Go through and uncomment the various lines that add the imports and the logging code. These are the following lines that need uncommenting:
+To add `log4j` all we need to do is to open up the `ListDir.java` file and uncomment some things in order to start using it. Go through and uncomment the various lines that add the imports and the logging code. Uncomment the following lines:
 
 ```java
 //import org.apache.log4j.Logger;
@@ -234,14 +238,14 @@ OK, so now we have added logging, let's see if it works by rebuilding and runnin
 $ mvn clean package exec:exec
 ```
 
-Great, that works. Now, let's build a native image using the maven profile:
+Great, that works. Now, let's build a native image using the Maven profile:
 
 ![User Input](./images/userinput.png)
 ```sh
 $ mvn clean package -Pnative
 ```
 
-The run the built image:
+Then run the executable:
 
 ![User Input](./images/userinput.png)
 ```sh

--- a/native-image-workshop/README.md
+++ b/native-image-workshop/README.md
@@ -1,51 +1,59 @@
 # GraalVM Native Image Workshop
 
+## Prerequisites
+
+* OS : Linux or Mac OSX
+* Apache Maven
+
 ## Introduction
 
-This workshop aims to walk you through a number of features GraalVM's Native Image offers,
-namely:
-
-1. Run a basic Java app
-2. Build a native image from it and see how that compares in terms of startup time
-3. Look at how we use the tracing agent to identify any dynamic features
-4. Run some of the application at the native image build time
-
-## Setup
-
-Install GraalVM. Instructions can be found [here](./SETUP-QUICK.md).
-
-You need a working version of Maven as well, and this should be covered in the installation instructions.
-
-## Outline of Demo
-
-We are going to use a fairly trivial application to walk through some of the features that
-are available with GraalVM's Native Image. These are:
+We are going to use a fairly trivial application to walk through using GraalVM Native Image. Along the way we will see:
 
 1. How you can turn a Java app into a native executable
-2. How you can deal with Java Reflection API calls, etc..
+2. How you can build a GraalVM Native IMage that works with the dynamic parts of Jva
 3. Using the command line tools for generating a native image, as well as using the Maven tooling
 
-The application is a Java command line app that counts the number of files within the current directory and sub directories.
-It also calculates their total size.
+So what is going to be our testbed application? We will use a command line Java application that counts the number of files within the current directory and sub directories. As a nice extra it also calculates their total size.
 
-You will need to update the code, in the following various steps, in order to work through the points we listed above.
+As you work through this workshop you will need to update the code, in the following steps.
+
+This workshop relies on using GraalVM 21.3 or higher, with the GraalVM Native Image package installed. It will work with either Community Edition (CE), or Enterprise Edition (EE). If there is any EE speific code / configuration, this will be clearly marked out.
 
 Let's beign!
 
-## Quick Note on Using Maven Profile
+## Setup
 
-The Maven build has been split into several different profiles, each of which serves a different purpose. We can call these profiles by passing a parameter that contains the name of the profile to maven. In the example below the `JAVA` profile is called:
+Install GraalVM. Instructions can be found [here](https://www.graalvm.org/docs/getting-started/.
+
+You will need the following installed:
+
+* GraalVM 21.3.0 JDK 11 or JDK17 installed (either EE or CE)
+* Native Image plugin that matches your GraalVM installation
+
+## Quick Note on Using Maven Profiles
+
+This workshop will use Maven profiles. Proflies are a great way to have different build configurtions within a single `pom.xml` file. You can find out more about them [here](https://maven.apache.org/guides/introduction/introduction-to-profiles.html).
+
+We will use several profiles throughout the project, each of which will serve a different purpose. We are able to call these profiles by passing a parameter containing the name of the profile to maven. The example below shows how we would call the `JAVA` profile, when building with maven:
 
 ![User Input](./images/userinput.png)
 ```sh
 $ mvn clean package -PJAVA
 ```
 
-The name of the profile to be called is appended to the `-P` flag. We have the following profiles defined in the maven file:
+The name of the profile to be called is appended to the `-P` flag. We use these profiles within this workshop (all defined in the `pom.xml` file):
 
-1. `JAVA` : This builds the Java applicaiton
-2. `JAVA_AGENT_LIB` : Ths builds the Java application with the tracing agent
-3. `NATIVE_IMAGE` : This builds the native image
+1. `java_agent` : Ths builds the Java application with the tracing agent
+2. `native` : This builds the native image
+
+## The Java App
+
+The Java application can be found in the `src` directory and it consists of two files. 
+
+* `App.java` : A wrapper for  the `ListDir` application
+* `ListDir.java` : This does all the work, counting the files an summarising the output
+
+We build our application using a maven, `pom.xml` file. Now we have had a basic understanding of our application, let's build our application and see how it works.
 
 ## Build the Basic Java App
 
@@ -55,7 +63,7 @@ From a command line:
 
 ![User Input](./images/userinput.png)
 ```sh
-$ mvn clean package exec:exec -PJAVA
+$ mvn clean package exec:exec
 ```
 
 What the above command does:
@@ -78,9 +86,9 @@ Did it work for you?
 
 ## Build a Native Image from the App
 
-Next, build a native image version of the application.
+Next, you are going to build a native image version of the application. This will start quicker than the Java application.
 
-We will do this by hand first. To begin, check that you have a compiled uber JAR in your `target` dir:
+We will do this by hand first, using the `native-image` tool.. To begin, check that you have a compiled uber JAR in your `target` dir:
 
 ![User Input](./images/userinput.png)
 ```sh
@@ -96,11 +104,13 @@ $ ls ./target
 
 The file you will need is, `graalvmnidemos-1.0-SNAPSHOT-jar-with-dependencies.jar`.
 
+**NOTE** : You will need to have installed the GraalVM Native Image package for GraalVM - see the set up instructions.
+
 Now you can generate a native image as follows, within the root of the project:
 
 ![User Input](./images/userinput.png)
 ```sh
-$ native-image -jar ./target/graalvmnidemos-1.0-SNAPSHOT-jar-with-dependencies.jar --no-fallback --no-server -H:Class=oracle.App -H:Name=file-count
+$ native-image -jar ./target/graalvmnidemos-1.0-SNAPSHOT-jar-with-dependencies.jar --no-fallback -H:Class=oracle.App -H:Name=file-count
 ```
 
 This will generate a file called `file-count`, which you can run as follows:
@@ -124,9 +134,8 @@ Compare that to the time running the app with the regular `java` command:
 time java -cp ./target/graalvmnidemos-1.0-SNAPSHOT-jar-with-dependencies.jar oracle.App
 ```
 
-What do the various parameters we passed to the `native-image` command do? Full documentation on these can be found [here](https://www.graalvm.org/docs/reference-manual/native-image/#image-generation-options):
+What do the various parameters we passed to the `native-image` command do? Full documentation on these can be found [here](https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/):
 
-* `--no-server`: Do not start a build server process. For these examples we just want to run the builds. It is possible to run the builds through a build server.
 * `--no-fallback`: Do not generate a fallback image. A fallback image requires the JVM to run, and we do not want this.We just want it to be a native image.
 * `-H:Class`: Tell the `native-image` builder which class is the entry point method (the `main` method).
 * `-H:Name`: Specify what the output executable file should be called.
@@ -136,25 +145,33 @@ We can also run the `native-image` tool using Maven. If you look at the `pom.xml
 ```xml
 <!-- Native Image -->
 <plugin>
-    <groupId>org.graalvm.nativeimage</groupId>
-    <artifactId>native-image-maven-plugin</artifactId>
-    <version>${graalvm.version}</version>
+    <groupId>org.graalvm.buildtools</groupId>
+    <artifactId>native-maven-plugin</artifactId>
+    <version>${native.maven.plugin.version}</version>
+    <extensions>true</extensions>
     <executions>
-        <execution>
-            <goals>
-                <goal>native-image</goal>
-            </goals>
-            <phase>package</phase>
-        </execution>
+    <execution>
+        <id>build-native</id>
+        <goals>
+        <goal>build</goal>
+        </goals>
+        <phase>package</phase>
+    </execution>
     </executions>
     <configuration>
         <!-- Set this to true if you need to switch this off -->
         <skip>false</skip>
         <!-- The output name for the executable -->
         <imageName>${exe.file.name}</imageName>
-        <!-- Set any parameters you need to pass to native-image tool.-->
+        <mainClass>${app.main.class}</mainClass>
         <buildArgs>
-            --no-fallback --no-server
+            <!-- Don't create a antive exe that falls back to starting a JVM if the image won't build -->
+            <buildArg>--no-fallback</buildArg>
+            <!-- Warn about features that arent supported by native image at the runtime of the image.
+                If there is any reflection, for example, this will generate an error at the runtime of
+                native image.
+            -->
+            <buildArg>--report-unsupported-elements-at-runtime</buildArg>
         </buildArgs>
     </configuration>
 </plugin>
@@ -166,7 +183,7 @@ To build the native image using maven:
 
 ![User Input](./images/userinput.png)
 ```sh
-$ mvn clean package -PNATIVE_IMAGE
+$ mvn clean package -Pnative
 ```
 
 **Note**: The maven build places the executable, `file-count`, in the `target` directory.
@@ -179,11 +196,11 @@ relies on reflection. A good candidate for testing this out would be to add `log
 We've already added it as a dependency in the `pom.xml` file, and it can be seen in the depencies:
 
 ```xml
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
+<dependency>
+    <groupId>log4j</groupId>
+    <artifactId>log4j</artifactId>
+    <version>1.2.17</version>
+</dependency>
 ```
 
 To add `log4j` all we need to do is to open up the `ListDir.java` file and uncomment some things in order to start using it. Go through and uncomment the various lines that add the imports and the logging code. These are the following lines that need uncommenting:
@@ -214,14 +231,14 @@ OK, so now we have added logging, let's see if it works by rebuilding and runnin
 
 ![User Input](./images/userinput.png)
 ```sh
-$ mvn clean package exec:exec -PJAVA
+$ mvn clean package exec:exec
 ```
 
 Great, that works. Now, let's build a native image using the maven profile:
 
 ![User Input](./images/userinput.png)
 ```sh
-$ mvn clean package -PNATIVE_IMAGE
+$ mvn clean package -Pnative
 ```
 
 The run the built image:
@@ -237,20 +254,13 @@ This generates an error:
 Exception in thread "main" java.lang.NoClassDefFoundError
         at org.apache.log4j.Category.class$(Category.java:118)
         at org.apache.log4j.Category.<clinit>(Category.java:118)
-        at com.oracle.svm.core.hub.ClassInitializationInfo.invokeClassInitializer(ClassInitializationInfo.java:350)
-        at com.oracle.svm.core.hub.ClassInitializationInfo.initialize(ClassInitializationInfo.java:270)
-        at java.lang.Class.ensureInitialized(DynamicHub.java:496)
-        at com.oracle.svm.core.hub.ClassInitializationInfo.initialize(ClassInitializationInfo.java:235)
-        at java.lang.Class.ensureInitialized(DynamicHub.java:496)
+        at java.lang.Class.ensureInitialized(DynamicHub.java:552)
         at oracle.ListDir.<clinit>(ListDir.java:75)
-        at com.oracle.svm.core.hub.ClassInitializationInfo.invokeClassInitializer(ClassInitializationInfo.java:350)
-        at com.oracle.svm.core.hub.ClassInitializationInfo.initialize(ClassInitializationInfo.java:270)
-        at java.lang.Class.ensureInitialized(DynamicHub.java:496)
         at oracle.App.main(App.java:63)
 Caused by: java.lang.ClassNotFoundException: org.apache.log4j.Category
-        at com.oracle.svm.core.hub.ClassForNameSupport.forName(ClassForNameSupport.java:60)
-        at java.lang.Class.forName(DynamicHub.java:1211)
-        ... 12 more
+        at java.lang.Class.forName(DynamicHub.java:1433)
+        at java.lang.Class.forName(DynamicHub.java:1408)
+        ... 5 more
 ```
 
 Why? This is caused by the addition of the Log4J library. This library depends heavily upon the reflection calls,
@@ -286,14 +296,14 @@ The files should now be present.
 
 ![User Input](./images/userinput.png)
 ```sh
-$ mvn clean package exec:exec -PJAVA_AGENT_LIB
+$ mvn clean package exec:exec -Pjava_agent
 ```
 
 Now, you run the native image generation again, and then execute the generated image:
 
 ![User Input](./images/userinput.png)
 ```sh
-$ mvn package -PNATIVE_IMAGE
+$ mvn package -Pnative
 $ time ./target/.file-count
 ```
 

--- a/native-image-workshop/pom.xml
+++ b/native-image-workshop/pom.xml
@@ -13,6 +13,9 @@
         <graalvm.version>20.0.0</graalvm.version>
         <jackson.version>2.10.1</jackson.version>
         <app.main.class>oracle.App</app.main.class>
+        <!-- Define the version of the GraalVM Maven Plugin we want to use -->
+        <native.maven.plugin.version>0.9.7.1</native.maven.plugin.version>
+        <!-- We can use properties to define the name of the executable we produce -->
         <exe.file.name>file-count</exe.file.name>
     </properties>
 
@@ -31,72 +34,13 @@
     </dependencies>
 
     <profiles>
-        <!-- This is the profile for running the JIT version of the app. To run:
-
-            $ mvn clean package exec:exec -PJAVA
-        -->
-        <profile>
-            <id>JAVA</id>
-            <build>
-                <!-- Compiler -->
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.0</version>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                        </configuration>
-                    </plugin>
-                    <!-- Package -->
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <configuration>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                                <archive>
-                                <manifest>
-                                    <!-- Specify the main class -->
-                                    <mainClass>${app.main.class}</mainClass>
-                                </manifest>
-                            </archive>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>make-assembly</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!-- Run the app, quick way of testing the Java version -->
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.2</version>
-                        <configuration>
-                            <executable>java</executable>
-                            <arguments>
-                                <argument>-classpath</argument>
-                                <classpath />
-                                <argument>${app.main.class}</argument>
-                            </arguments>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <!-- This is the profile for running the JIT version of the app AND RUNNING THE AGENTLIB
             to profile the app to identify reflection etc. To run:
 
             $ mvn clean package exec:exec -PJAVA_AGENT_LIB
         -->
         <profile>
-            <id>JAVA_AGENT_LIB</id>
+            <id>java_agent</id>
             <build>
                 <plugins>
                     <!-- Compiler -->
@@ -160,68 +104,35 @@
             $ mvn clean package exec:exec -PNATIVE_IMAGE
         -->
         <profile>
-            <id>NATIVE_IMAGE</id>
+            <id>native</id>
             <build>
                 <plugins>
-                    <!-- Compiler -->
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.0</version>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                        </configuration>
-                    </plugin>
-                    <!-- Package -->
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <configuration>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                                <archive>
-                                <manifest>
-                                    <!-- Specify the main class -->
-                                    <mainClass>${app.main.class}</mainClass>
-                                </manifest>
-                            </archive>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>make-assembly</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!-- Native Image -->
                     <plugin>
-                        <groupId>org.graalvm.nativeimage</groupId>
-                        <artifactId>native-image-maven-plugin</artifactId>
-                        <version>${graalvm.version}</version>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native.maven.plugin.version}</version>
+                        <extensions>true</extensions>
                         <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <phase>package</phase>
-                            </execution>
+                        <execution>
+                            <id>build-native</id>
+                            <goals>
+                            <goal>build</goal>
+                            </goals>
+                            <phase>package</phase>
+                        </execution>
                         </executions>
                         <configuration>
                             <!-- Set this to true if you need to switch this off -->
                             <skip>false</skip>
                             <!-- The output name for the executable -->
                             <imageName>${exe.file.name}</imageName>
-                            <!-- Set any parameters we need to pass to the native-image tool.
-                                no-fallback : create a native image that doesn't fall back to the JVM
-                                no-server : don't start a build server, which you then just need to shut down,
-                                            in order to build the image
-                            -->
+                            <mainClass>${app.main.class}</mainClass>
                             <buildArgs>
-                                --no-fallback --no-server
+                                <!-- With Enterprise you can use the G1GC -->
+                                <!--buildArg>- -gc=G1</buildArg-->
+                                <buildArg>--no-fallback</buildArg>
+                                <buildArg>--report-unsupported-elements-at-runtime</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>
@@ -229,4 +140,57 @@
             </build>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <!-- Compiler -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <!-- Package -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                        <archive>
+                        <manifest>
+                            <!-- Specify the main class -->
+                            <mainClass>${app.main.class}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Run the app, quick way of testing the Java version -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2</version>
+                <configuration>
+                    <executable>java</executable>
+                    <arguments>
+                        <argument>-classpath</argument>
+                        <classpath />
+                        <argument>${app.main.class}</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Now that we can build docker images and run containers on our local machine (see #93), the next thing to do is to try to do them on the cloud.

For most end-users/developers it will be running the docker container and the demo apps inside it, on a remote machine i.e. cloud.

The files accompanying this PR has the initial scripts/steps needed to get set up and then regularly run apps on the cloud, in this case, on the **Oracle Cloud Infrastructure (OCI)**. This is also helpful for instances where the local machine isn't powerful enough to build or run such containers.

Pre-requisites to be able to use this feature:
- an OCI account
- Terraform installed on the local machine
- ssh public & private key available (presence of `~/.ssh` or `c:\.ssh` folders)
- access to the [graalvm-demos](https://github.com/graalvm/graalvm-demos) repo
- necessary OCI configuration in a `.rc` file, as mentioned in the **README** file on this PR
- for the rest refer to the **README** file