### PR TITLE
Making the README of demo apps consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,5 @@ espresso-jshell/espresso-jshell
 espresso-jshell/espresso-jshell.build_artifacts.txt
 native-list-dir/extlistdir
 native-list-dir/extlistdir.build_artifacts.txt
+native-hello-module/hellomodule
+native-hello-module/hellomodule.build_artifacts.txt

--- a/native-hello-module/README.md
+++ b/native-hello-module/README.md
@@ -1,4 +1,52 @@
-### Building a HelloWorld Java module into a native-image
+### GraalVM Demos: Building a HelloWorld Java module into a native-image
+
+#### Prerequisites
+- [GraalVM](http://graalvm.org/) 
+   - version 21.3.0 or higher (Java 11 or higher, Java 8 not supported, as the modules feature was added in Java 9)
+- [Native Image](https://www.graalvm.org/docs/reference-manual/native-image/)
+
+#### Preparation
+
+This is a simple Java application, that demonstrates the use of modules in GraalVM and applying the `native-image` compiler to create a `native-image` from such modularised Java apps.
+
+1. [Download GraalVM](https://www.graalvm.org/downloads/), unzip the archive, export the GraalVM home directory as the `$JAVA_HOME` and add `$JAVA_HOME/bin` to the `PATH` environment variable.
+
+  On Linux:
+  ```bash
+  export JAVA_HOME=/home/${current_user}/path/to/graalvm
+  export PATH=$JAVA_HOME/bin:$PATH
+  ```
+  On macOS:
+  ```bash
+  export JAVA_HOME=/Users/${current_user}/path/to/graalvm/Contents/Home
+  export PATH=$JAVA_HOME/bin:$PATH
+  ```
+  On Windows:
+  ```bash
+  setx /M JAVA_HOME "C:\Progra~1\Java\<graalvm>"
+  setx /M PATH "C:\Progra~1\Java\<graalvm>\bin;%PATH%"
+  ```
+
+2. Install [Native Image](https://www.graalvm.org/docs/reference-manual/native-image/#install-native-image) by running:
+  ```bash
+  gu install native-image
+  ```
+
+3. Download or clone the repository and navigate into the `native-hello-module` directory:
+  ```bash
+  git clone https://github.com/graalvm/graalvm-demos
+  cd graalvm-demos/native-hello-module
+  ```
+
+#### Building the application
+
+```bash
+$ mvn package
+```
+
+A `target` folder with `HelloModule-1.0-SNAPSHOT.jar` will be created.
+
+#### Run the application
 
 The following modularized Java Hello World example
 
@@ -23,6 +71,10 @@ can be executed via Java using the following command:
     $ java --module-path target/HelloModule-1.0-SNAPSHOT.jar --module HelloModule
     Hello from Java Module: HelloModule
 
+    $ time java --module-path target/HelloModule-1.0-SNAPSHOT.jar --module HelloModule
+    Hello from Java Module: HelloModule
+
+
 With GraalVM 21.3 we can **now also build Java modules** into images. Using:
 
     $ native-image --module-path target/HelloModule-1.0-SNAPSHOT.jar --module HelloModule
@@ -37,4 +89,7 @@ With GraalVM 21.3 we can **now also build Java modules** into images. Using:
 builds the modular Java app into an image that can be executed with:
 
     $ ./hellomodule 
+    Hello from Java Module: HelloModule
+
+    $ time ./hellomodule 
     Hello from Java Module: HelloModule

--- a/native-hello-module/README.md
+++ b/native-hello-module/README.md
@@ -69,11 +69,14 @@ The following modularized Java Hello World example
 can be executed via Java using the following command:
 
     $ java --module-path target/HelloModule-1.0-SNAPSHOT.jar --module HelloModule
-    Hello from Java Module: HelloModule
+    Hello from Java Module: HelloModule    
 
     $ time java --module-path target/HelloModule-1.0-SNAPSHOT.jar --module HelloModule
     Hello from Java Module: HelloModule
-
+    
+    real	0m1.470s
+    user	0m0.863s
+    sys	    0m0.620s
 
 With GraalVM 21.3 we can **now also build Java modules** into images. Using:
 
@@ -93,3 +96,7 @@ builds the modular Java app into an image that can be executed with:
 
     $ time ./hellomodule 
     Hello from Java Module: HelloModule
+
+    real	0m0.544s
+    user	0m0.011s
+    sys	    0m0.031s


### PR DESCRIPTION
A handful of demo apps do not have the basic steps needed to set up the environments or run the apps, or install dependencies.

The following demo apps are going to be updated, and made consistent:

- [x] [native-hello-module](https://github.com/graalvm/graalvm-demos/tree/master/native-hello-module):  Updated the README to contain GraalVM setup information, making it consistent like the other apps
- [ ] [functionGraphDemo](https://github.com/graalvm/graalvm-demos/tree/master/functionGraphDemo)
- [ ] [galaaz-ggplot](https://github.com/graalvm/graalvm-demos/tree/master/galaaz-ggplot)
- [ ] [graalpython-notebook-example](https://github.com/graalvm/graalvm-demos/tree/master/graalpython-notebook-example)