### PR TITLE
build native image for ExtListDir according README

### DIFF
--- a/native-list-dir/build.sh
+++ b/native-list-dir/build.sh
@@ -4,5 +4,5 @@ set -ex
 $JAVA_HOME/bin/javac ListDir.java
 $JAVA_HOME/bin/native-image ListDir
 
-#javac ExtListDir.java
-#$GRAALVM_HOME/bin/native-image --language:js ExtListDir
+#$JAVA_HOME/bin/javac ExtListDir.java
+#$JAVA_HOME/bin/native-image --language:js ExtListDir


### PR DESCRIPTION
The `build.sh` builds by default the native image for `ListDir.java`. However, it contains also the commented out statements to build the native image for `ExtListDir.java`. 

This PR changes the commands in `build.sh` to match them documented in the [README.md](https://github.com/graalvm/graalvm-demos/blob/master/native-list-dir/README.md#polyglot-capabilities). 