### PR TITLE
README.md: broken link and missing requisites

### DIFF
--- a/native-image-configure-examples/README.md
+++ b/native-image-configure-examples/README.md
@@ -38,10 +38,11 @@ To learn more about this topic, read [Initialize Once, Start Fast: Application I
   setx /M PATH "C:\Progra~1\Java\<graalvm>\bin;%PATH%"
   ```
 
-2. Install [Native Image](https://www.graalvm.org/docs/reference-manual/native-image/#install-native-image) by running:
+2. Install [Native Image](https://www.graalvm.org/dev/reference-manual/native-image/#install-native-image) by running:
   ```bash
   gu install native-image
   ```
+  You will also need to provide some native compiler toolchain prerequisites.
 
 3. Download or clone the demos repository::
   ```


### PR DESCRIPTION
The doc link is broken and it does not mention the additional tools needed.

This change uses the dev-branch since this seems better than regularly updating the release version. A latest branch on the doc site would be better.