### PR TITLE
Upgraded JDK and GraalVM versions in Cloud Shell

### DIFF
--- a/_common/README-check-version-env-vars.md
+++ b/_common/README-check-version-env-vars.md
@@ -9,9 +9,9 @@
     The output should be similar to:
 
     ```shell
-    * graalvmeejdk-17.0.4                                    /usr/lib64/graalvm/graalvm22-ee-java17
-      openjdk-11.0.15                   /usr/lib/jvm/java-11-openjdk-11.0.15.0.9-2.0.1.el7_9.x86_64
-      openjdk-1.8.0.332                /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64
+    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
+      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
+      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
     ```
 
 2. Confirm the environment variable `JAVA_HOME` is set correctly:
@@ -35,7 +35,7 @@
     The output should be similar to:
 
     ```shell
-    /usr/lib64/graalvm/graalvm22-ee-java17/bin/:/ggs_client/usr/bin: ...
+    /usr/lib64/graalvm/graalvm22-ee-java17/bin/:...
     ```
 
 4. Confirm the `java` version:
@@ -47,9 +47,9 @@
     The output should be similar to:
 
     ```shell
-    java version "17.0.4" 2022-07-19 LTS   
-    Java(TM) SE Runtime Environment GraalVM EE 22.2.0 (build 17.0.4+11-LTS-jvmci-22.2-b05)   
-    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.2.0 (build 17.0.4+11-LTS-jvmci-22.2-b05, mixed mode, sharing)
+    java version "17.0.4.1" 2022-08-18 LTS
+    Java(TM) SE Runtime Environment GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08)
+    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08, mixed mode, sharing)s
     ```
 
 5. Confirm the `native-image` version:
@@ -61,7 +61,7 @@
     The output should be similar to:
 
     ```shell
-    GraalVM 22.2.0 Java 17 EE (Java Version 17.0.4+11-LTS-jvmci-22.2-b05)
+    GraalVM 22.2.0.1 Java 17 EE (Java Version 17.0.4.1+1-LTS-jvmci-22.2-b08)
     ```
 
 6. Confirm the `Java` used for Maven builds:
@@ -74,7 +74,7 @@
 
     ```shell
     ...
-    Java version: 17.0.4, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
+    Java version: 17.0.4.1, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
     ...
     ```
 

--- a/java-hello-world-maven/README-Cloud-Shell.md
+++ b/java-hello-world-maven/README-Cloud-Shell.md
@@ -29,21 +29,21 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     The output should be similar to:
 
     ```shell
-      graalvmeejdk-17.0.4                                    /usr/lib64/graalvm/graalvm22-ee-java17
-    * openjdk-11.0.15                   /usr/lib/jvm/java-11-openjdk-11.0.15.0.9-2.0.1.el7_9.x86_64
-      openjdk-1.8.0.332                /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64
+      graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
+    * openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
+      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4
+    csruntimectl java set graalvmeejdk-17.0.4.1
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.
+    The current managed java version is set to graalvmeejdk-17.0.4.1.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables
@@ -118,51 +118,51 @@ You will notice the `Quick Build` mode reduces the time required to generate a n
     ...
     You enabled -Ob for this image build. This will configure some optimizations to reduce image build time.
     ...
-    ================================================================================================
+    ========================================================================================================================
     GraalVM Native Image: Generating 'my-app' (executable)...
-    ================================================================================================
-    [1/7] Initializing...                                                           (10.4s @ 0.21GB)
-    Version info: 'GraalVM 22.2.0 Java 17 EE'
-    Java version info: '17.0.4+11-LTS-jvmci-22.2-b05'
+    ========================================================================================================================
+    [1/7] Initializing...                                                                                   (10.7s @ 0.21GB)
+    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
+    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
     C compiler: gcc (redhat, x86_64, 11.2.1)
     Garbage collector: Serial GC
-    [2/7] Performing analysis...  [*****]                                           (18.3s @ 0.72GB)
-    1,826 (62.38%) of  2,927 classes reachable
-    1,665 (46.89%) of  3,551 fields reachable
-    7,652 (37.12%) of 20,613 methods reachable
-        21 classes,     0 fields, and   258 methods registered for reflection
+    [2/7] Performing analysis...  [*****]                                                                   (20.4s @ 0.68GB)
+    1,819 (62.34%) of  2,918 classes reachable
+    1,662 (46.88%) of  3,545 fields reachable
+    7,638 (37.13%) of 20,569 methods reachable
+        17 classes,     0 fields, and   254 methods registered for reflection
         49 classes,    32 fields, and    48 methods registered for JNI access
         4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                       (3.2s @ 0.97GB)
-    [4/7] Parsing methods...      [**]                                               (2.8s @ 0.40GB)
-    [5/7] Inlining methods...     [***]                                              (1.7s @ 0.66GB)
-    [6/7] Compiling methods...    [***]                                             (10.0s @ 0.82GB)
-    [7/7] Creating image...                                                          (2.3s @ 1.01GB)
-    1.78MB (42.88%) for code area:     4,439 compilation units
-    2.23MB (53.52%) for image heap:   36,753 objects and 1 resources
-    153.49KB ( 3.60%) for other data
+    [3/7] Building universe...                                                                               (3.0s @ 0.93GB)
+    [4/7] Parsing methods...      [**]                                                                       (2.7s @ 0.36GB)
+    [5/7] Inlining methods...     [***]                                                                      (1.9s @ 0.60GB)
+    [6/7] Compiling methods...    [***]                                                                     (11.0s @ 0.72GB)
+    [7/7] Creating image...                                                                                  (1.9s @ 0.91GB)
+    1.78MB (42.86%) for code area:     4,433 compilation units
+    2.23MB (53.52%) for image heap:   36,677 objects and 1 resources
+    154.55KB ( 3.63%) for other data
     4.16MB in total
-    ------------------------------------------------------------------------------------------------
+    ------------------------------------------------------------------------------------------------------------------------
     Top 10 packages in code area:                               Top 10 object types in image heap:
-    208.78KB com.oracle.svm.jni                                 374.04KB byte[] for code metadata
-    184.72KB java.lang                                          317.32KB byte[] for java.lang.String
-    169.35KB com.oracle.svm.core.code                           268.43KB java.lang.Class
-    144.00KB java.util                                          263.72KB java.lang.String
-    104.52KB com.oracle.svm.core.genscavenge                    213.43KB byte[] for general heap data
+    208.78KB com.oracle.svm.jni                                 373.80KB byte[] for code metadata
+    184.72KB java.lang                                          316.52KB byte[] for java.lang.String
+    168.31KB com.oracle.svm.core.code                           267.37KB java.lang.Class
+    144.00KB java.util                                          263.25KB java.lang.String
+    104.52KB com.oracle.svm.core.genscavenge                    213.14KB byte[] for general heap data
     80.73KB java.util.concurrent                               111.71KB char[]
-    64.87KB java.lang.invoke                      71.33KB com.oracle.svm.core.hub.DynamicHubCompanion
-    52.95KB java.math                                          68.66KB byte[] for reflection metadata
-    44.58KB com.oracle.svm.jni.functions       50.56KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
-    40.69KB java.io                                             45.11KB java.util.HashMap$Node[]
-    700.71KB for 99 more packages                               347.71KB for 478 more object types
-    ------------------------------------------------------------------------------------------------
-                1.1s (2.2% of total time) in 14 GCs | Peak RSS: 1.61GB | CPU load: 1.60
-    ------------------------------------------------------------------------------------------------
+    64.87KB java.lang.invoke                                    71.05KB com.oracle.svm.core.hub.DynamicHubCompanion
+    52.95KB java.math                                           68.35KB byte[] for reflection metadata
+    44.58KB com.oracle.svm.jni.functions                        50.34KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
+    40.68KB java.io                                             44.95KB java.util.HashMap$Node[]
+    700.72KB for 99 more packages                               346.14KB for 478 more object types
+    ------------------------------------------------------------------------------------------------------------------------
+                            1.5s (2.7% of total time) in 14 GCs | Peak RSS: 1.65GB | CPU load: 1.77
+    ------------------------------------------------------------------------------------------------------------------------
     Produced artifacts:
-    /home/user_graal/gvme-java-hello-world/target/my-app (executable)
-    /home/user_graal/gvme-java-hello-world/target/my-app.build_artifacts.txt (txt)
-    ================================================================================================
-    Finished generating 'my-app' in 50.8s.
+    /home/user_graal/java-hello-world-maven/target/my-app (executable)
+    /home/user_graal/java-hello-world-maven/target/my-app.build_artifacts.txt (txt)
+    ========================================================================================================================
+    Finished generating 'my-app' in 53.5s.
     ...
     ```
 
@@ -199,51 +199,51 @@ You will notice the `Quick Build` mode reduces the time required to generate a n
 
     ```
     ...
-    ================================================================================================
+    ========================================================================================================================
     GraalVM Native Image: Generating 'my-app' (executable)...
-    ================================================================================================
-    [1/7] Initializing...                                                           (16.7s @ 0.23GB)
-    Version info: 'GraalVM 22.2.0 Java 17 EE'
-    Java version info: '17.0.4+11-LTS-jvmci-22.2-b05'
+    ========================================================================================================================
+    [1/7] Initializing...                                                                                   (10.8s @ 0.23GB)
+    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
+    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
     C compiler: gcc (redhat, x86_64, 11.2.1)
     Garbage collector: Serial GC
-    [2/7] Performing analysis...  [*****]                                           (30.8s @ 0.76GB)
-    1,865 (61.63%) of  3,026 classes reachable
-    1,701 (47.24%) of  3,601 fields reachable
-    7,647 (36.18%) of 21,135 methods reachable
-        21 classes,     0 fields, and   258 methods registered for reflection
+    [2/7] Performing analysis...  [*****]                                                                   (20.2s @ 0.69GB)
+    1,858 (61.54%) of  3,019 classes reachable
+    1,698 (47.23%) of  3,595 fields reachable
+    7,633 (36.19%) of 21,092 methods reachable
+        17 classes,     0 fields, and   254 methods registered for reflection
         49 classes,    32 fields, and    48 methods registered for JNI access
         4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                       (5.2s @ 1.03GB)
-    [4/7] Parsing methods...      [**]                                               (4.6s @ 0.47GB)
-    [5/7] Inlining methods...     [***]                                              (2.8s @ 0.73GB)
-    [6/7] Compiling methods...    [********]                                        (72.4s @ 2.42GB)
-    [7/7] Creating image...                                                          (3.4s @ 0.28GB)
-    2.50MB (49.19%) for code area:     3,718 compilation units
-    2.43MB (47.85%) for image heap:   37,067 objects and 1 resources
-    154.51KB ( 2.97%) for other data
-    5.09MB in total
-    ------------------------------------------------------------------------------------------------
+    [3/7] Building universe...                                                                               (3.0s @ 0.95GB)
+    [4/7] Parsing methods...      [**]                                                                       (2.9s @ 0.39GB)
+    [5/7] Inlining methods...     [***]                                                                      (1.5s @ 0.64GB)
+    [6/7] Compiling methods...    [******]                                                                  (44.7s @ 2.12GB)
+    [7/7] Creating image...                                                                                  (2.1s @ 2.34GB)
+    2.50MB (49.19%) for code area:     3,714 compilation units
+    2.43MB (47.88%) for image heap:   36,993 objects and 1 resources
+    152.23KB ( 2.92%) for other data
+    5.08MB in total
+    ------------------------------------------------------------------------------------------------------------------------
     Top 10 packages in code area:                               Top 10 object types in image heap:
-    299.90KB java.lang                                          508.60KB byte[] for code metadata
-    193.82KB com.oracle.svm.jni                                 319.97KB byte[] for java.lang.String
-    190.79KB java.util                                          288.09KB java.lang.Class
-    157.50KB com.oracle.svm.core.code                           265.69KB java.lang.String
-    118.87KB com.oracle.svm.core.genscavenge                    215.05KB byte[] for general heap data
+    299.87KB java.lang                                          508.50KB byte[] for code metadata
+    193.82KB com.oracle.svm.jni                                 319.17KB byte[] for java.lang.String
+    190.77KB java.util                                          272.45KB java.lang.Class
+    155.80KB com.oracle.svm.core.code                           265.22KB java.lang.String
+    118.87KB com.oracle.svm.core.genscavenge                    214.75KB byte[] for general heap data
     111.79KB java.util.concurrent                               111.71KB char[]
-    75.69KB java.lang.invoke                      72.85KB com.oracle.svm.core.hub.DynamicHubCompanion
-    73.33KB java.math                                          69.74KB byte[] for reflection metadata
-    71.31KB jdk.proxy4                         51.44KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
-    68.17KB com.oracle.svm.core                                 45.11KB java.util.HashMap$Node[]
-    1.15MB for 96 more packages                               348.00KB for 474 more object types
-    ------------------------------------------------------------------------------------------------
-                2.2s (1.5% of total time) in 18 GCs | Peak RSS: 2.97GB | CPU load: 0.99
-    ------------------------------------------------------------------------------------------------
+    75.68KB java.lang.invoke                                    72.58KB com.oracle.svm.core.hub.DynamicHubCompanion
+    73.33KB java.math                                           69.43KB byte[] for reflection metadata
+    71.31KB jdk.proxy4                                          51.22KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
+    68.17KB com.oracle.svm.core                                 44.95KB java.util.HashMap$Node[]
+    1.15MB for 96 more packages                               348.99KB for 474 more object types
+    ------------------------------------------------------------------------------------------------------------------------
+                            1.5s (1.7% of total time) in 17 GCs | Peak RSS: 2.94GB | CPU load: 1.76
+    ------------------------------------------------------------------------------------------------------------------------
     Produced artifacts:
-    /home/user_graal/gvme-java-hello-world/target/my-app (executable)
-    /home/user_graal/gvme-java-hello-world/target/my-app.build_artifacts.txt (txt)
-    ================================================================================================
-    Finished generating 'my-app' in 2m 19s.
+    /home/user_graal/java-hello-world-maven/target/my-app (executable)
+    /home/user_graal/java-hello-world-maven/target/my-app.build_artifacts.txt (txt)
+    ========================================================================================================================
+    Finished generating 'my-app' in 1m 28s.
     ...
     ```
 

--- a/micronaut-hello-rest-maven/README-Cloud-Shell.md
+++ b/micronaut-hello-rest-maven/README-Cloud-Shell.md
@@ -35,21 +35,21 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     The output should be similar to:
 
     ```shell
-      graalvmeejdk-17.0.4                                    /usr/lib64/graalvm/graalvm22-ee-java17
-    * openjdk-11.0.15                   /usr/lib/jvm/java-11-openjdk-11.0.15.0.9-2.0.1.el7_9.x86_64
-      openjdk-1.8.0.332                /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64
+    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
+      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
+      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4
+    csruntimectl java set graalvmeejdk-17.0.4.1
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.
+    The current managed java version is set to graalvmeejdk-17.0.4.1.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables
@@ -141,56 +141,56 @@ Use GraalVM Native Image to produce a native executable.
     ...
     You enabled -Ob for this image build. This will configure some optimizations to reduce image build time.
     ...
-    ==============================================================================================================
+    ========================================================================================================================
     GraalVM Native Image: Generating 'MnHelloRest' (executable)...
-    ==============================================================================================================
-    [1/7] Initializing...                                                                         (14.8s @ 0.14GB)
-     Version info: 'GraalVM 22.2.0 Java 17 EE'
-     Java version info: '17.0.4+11-LTS-jvmci-22.2-b05'
-     C compiler: gcc (redhat, x86_64, 11.2.1)
-     Garbage collector: Serial GC
-     4 user-specific feature(s)
-     - io.micronaut.buffer.netty.NettyFeature
-     - io.micronaut.core.graal.ServiceLoaderFeature
-     - io.micronaut.http.netty.graal.HttpNettyFeature
-     - io.micronaut.jackson.JacksonDatabindFeature
-    [2/7] Performing analysis...  [*********]                                                    (134.8s @ 1.36GB)
-      13,633 (91.99%) of 14,820 classes reachable
-      18,746 (56.91%) of 32,942 fields reachable
-      73,576 (63.75%) of 115,405 methods reachable
-         753 classes,   342 fields, and 2,788 methods registered for reflection
-          63 classes,    68 fields, and    55 methods registered for JNI access
-           4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                    (16.3s @ 1.51GB)
-    [4/7] Parsing methods...      [****]                                                          (19.9s @ 1.69GB)
-    [5/7] Inlining methods...     [***]                                                            (7.9s @ 1.40GB)
-    [6/7] Compiling methods...    [********]                                                      (67.1s @ 2.21GB)
-    [7/7] Creating image...                                                                       (12.4s @ 2.23GB)
-      19.93MB (47.43%) for code area:    52,033 compilation units
-      21.77MB (51.81%) for image heap:  340,838 objects and 292 resources
-     327.48KB ( 0.76%) for other data
-      42.02MB in total
-    --------------------------------------------------------------------------------------------------------------
-    Top 10 packages in code area:                          Top 10 object types in image heap:
-       1.83MB com.oracle.svm.core.code                        4.60MB byte[] for code metadata
-       1.18MB sun.security.ssl                                3.00MB byte[] for java.lang.String
-     750.79KB java.util                                       2.93MB java.lang.Class
-     465.04KB com.sun.crypto.provider                         2.21MB java.lang.String
-     424.19KB java.lang.invoke                                2.06MB byte[] for general heap data
-     407.35KB java.text                                     765.40KB byte[] for reflection metadata
-     406.78KB io.netty.buffer                               639.05KB com.oracle.svm.core.hub.DynamicHubCompanion
-     386.15KB reactor.core.publisher                        407.69KB java.util.concurrent.ConcurrentHashMap$Node
-     372.09KB java.lang                                     392.31KB c.o.s.core.hub.DynamicHub$ReflectionMetadata
-     364.29KB io.netty.handler.codec.http2                  377.50KB java.util.HashMap$Node
-      13.05MB for 501 more packages                           3.64MB for 3063 more object types
-    --------------------------------------------------------------------------------------------------------------
-                       13.6s (4.8% of total time) in 35 GCs | Peak RSS: 4.14GB | CPU load: 1.77
-    --------------------------------------------------------------------------------------------------------------
+    ========================================================================================================================
+    [1/7] Initializing...                                                                                   (14.1s @ 0.15GB)
+    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
+    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
+    C compiler: gcc (redhat, x86_64, 11.2.1)
+    Garbage collector: Serial GC
+    4 user-specific feature(s)
+    - io.micronaut.buffer.netty.NettyFeature
+    - io.micronaut.core.graal.ServiceLoaderFeature
+    - io.micronaut.http.netty.graal.HttpNettyFeature
+    - io.micronaut.jackson.JacksonDatabindFeature
+    [2/7] Performing analysis...  [*********]                                                              (146.6s @ 2.75GB)
+    13,627 (91.99%) of 14,814 classes reachable
+    18,736 (56.89%) of 32,931 fields reachable
+    73,543 (63.74%) of 115,373 methods reachable
+        749 classes,   342 fields, and 2,783 methods registered for reflection
+        63 classes,    68 fields, and    55 methods registered for JNI access
+        4 native libraries: dl, pthread, rt, z
+    [3/7] Building universe...                                                                              (26.1s @ 2.75GB)
+    [4/7] Parsing methods...      [******]                                                                  (33.1s @ 2.17GB)
+    [5/7] Inlining methods...     [***]                                                                     (10.1s @ 1.72GB)
+    [6/7] Compiling methods...    [********]                                                                (66.3s @ 2.49GB)
+    [7/7] Creating image...                                                                                 (14.1s @ 2.12GB)
+    19.92MB (47.42%) for code area:    52,012 compilation units
+    21.77MB (51.81%) for image heap:  340,805 objects and 292 resources
+    331.24KB ( 0.77%) for other data
+    42.02MB in total
+    ------------------------------------------------------------------------------------------------------------------------
+    Top 10 packages in code area:                               Top 10 object types in image heap:
+    1.83MB com.oracle.svm.core.code                             4.60MB byte[] for code metadata
+    1.18MB sun.security.ssl                                     3.00MB byte[] for java.lang.String
+    750.93KB java.util                                            2.93MB java.lang.Class
+    465.06KB com.sun.crypto.provider                              2.21MB java.lang.String
+    424.19KB java.lang.invoke                                     2.06MB byte[] for general heap data
+    407.29KB java.text                                          764.93KB byte[] for reflection metadata
+    406.78KB io.netty.buffer                                    638.77KB com.oracle.svm.core.hub.DynamicHubCompanion
+    386.12KB reactor.core.publisher                             407.97KB java.util.concurrent.ConcurrentHashMap$Node
+    372.08KB java.lang                                          392.13KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
+    364.26KB io.netty.handler.codec.http2                       377.50KB java.util.HashMap$Node
+    13.05MB for 501 more packages                                3.64MB for 3063 more object types
+    ------------------------------------------------------------------------------------------------------------------------
+                            17.3s (5.4% of total time) in 36 GCs | Peak RSS: 4.15GB | CPU load: 1.57
+    ------------------------------------------------------------------------------------------------------------------------
     Produced artifacts:
-     /home/sachin_pik/graalvmee-micronaut-hello-rest-maven/micronaut-hello-rest-maven/target/MnHelloRest (executable)
-     /home/sachin_pik/graalvmee-micronaut-hello-rest-maven/micronaut-hello-rest-maven/target/MnHelloRest.build_artifacts.txt (txt)
-    ==============================================================================================================
-    Finished generating 'MnHelloRest' in 4m 41s.
+    /home/graal_user/micronaut-hello-rest-maven/target/MnHelloRest (executable)
+    /home/graal_user/micronaut-hello-rest-maven/target/MnHelloRest.build_artifacts.txt (txt)
+    ========================================================================================================================
+    Finished generating 'MnHelloRest' in 5m 18s.
     ...    
     ```
     

--- a/micronaut-hello-rest-maven/pom.xml
+++ b/micronaut-hello-rest-maven/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>io.micronaut</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.1</version>
   </parent>
 
   <properties>
     <packaging>jar</packaging>
     <jdk.version>17</jdk.version>
     <release.version>17</release.version>
-    <micronaut.version>3.6.0</micronaut.version>
+    <micronaut.version>3.7.1</micronaut.version>
     <micronaut.runtime>netty</micronaut.runtime>
     <exec.mainClass>com.example.Application</exec.mainClass>
   </properties>

--- a/spring-native-image/README-Cloud-Shell.md
+++ b/spring-native-image/README-Cloud-Shell.md
@@ -29,21 +29,21 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     The output should be similar to:
 
     ```shell
-      graalvmeejdk-17.0.4                                    /usr/lib64/graalvm/graalvm22-ee-java17
-    * openjdk-11.0.15                   /usr/lib/jvm/java-11-openjdk-11.0.15.0.9-2.0.1.el7_9.x86_64
-      openjdk-1.8.0.332                /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64
+    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
+      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
+      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4
+    csruntimectl java set graalvmeejdk-17.0.4.1
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.
+    The current managed java version is set to graalvmeejdk-17.0.4.1.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables

--- a/spring-native-image/README-Code-Editor.md
+++ b/spring-native-image/README-Code-Editor.md
@@ -33,26 +33,27 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     The output should be similar to:
 
     ```shell
-      graalvmeejdk-17.0.4                                    /usr/lib64/graalvm/graalvm22-ee-java17
-    * openjdk-11.0.15                   /usr/lib/jvm/java-11-openjdk-11.0.15.0.9-2.0.1.el7_9.x86_64
-      openjdk-1.8.0.332                /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.332.b09-1.el7_9.x86_64
+    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
+      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
+      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4
+    csruntimectl java set graalvmeejdk-17.0.4.1
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.
+    The current managed java version is set to graalvmeejdk-17.0.4.1.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables
 
-This step is optional - [Check software version and environment variables](./README-check-version-env-vars.md)
+This step is optional - [Check software version and environment variables](../_common/README-check-version-env-vars.md)
+
 
 
 ## Step 4: Set up your project, build and run as a JAR
@@ -146,52 +147,52 @@ Let's build a native executable for our Spring Boot microservice using GraalVM E
     Warning: Could not register org.springframework.boot.autoconfigure.jdbc.HikariDriverConfigurationFailureAnalyzer: allDeclaredConstructors for reflection. Reason: java.lang.NoClassDefFoundError: org/springframework/jdbc/CannotGetJdbcConnectionException.
     Warning: Could not register org.springframework.boot.diagnostics.analyzer.ValidationExceptionFailureAnalyzer: allDeclaredConstructors for reflection. Reason: java.lang.NoClassDefFoundError: javax/validation/ValidationException.
     Warning: Could not register org.springframework.boot.liquibase.LiquibaseChangelogMissingFailureAnalyzer: allDeclaredConstructors for reflection. Reason: java.lang.NoClassDefFoundError: liquibase/exception/ChangeLogParseException.
-    [1/7] Initializing...                                                                         (16.4s @ 0.24GB)
-    Version info: 'GraalVM 22.2.0 Java 17 EE'
-    Java version info: '17.0.4+11-LTS-jvmci-22.2-b05'
+    [1/7] Initializing...                                                                         (16.9s @ 0.29GB)
+    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
+    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
     C compiler: gcc (redhat, x86_64, 11.2.1)
     Garbage collector: Serial GC
     1 user-specific feature(s)
     - com.oracle.svm.thirdparty.gson.GsonFeature
     The bundle named: org.apache.tomcat.util.threads.res.LocalStrings, has not been found. If the bundle is part of a module, verify the bundle name is a fully qualified class name. Otherwise verify the bundle path is accessible in the classpath.
     Warning: Could not register complete reflection metadata for org.springframework.validation.beanvalidation.SpringValidatorAdapter$ViolationFieldError. Reason(s): java.lang.NoClassDefFoundError: javax/validation/Validator
-    [2/7] Performing analysis...  [*******]                                                      (164.3s @ 3.16GB)
-    15,666 (91.31%) of 17,157 classes reachable
-    23,905 (66.65%) of 35,869 fields reachable
-    81,182 (65.28%) of 124,351 methods reachable
-        923 classes,   268 fields, and 4,431 methods registered for reflection
+    [2/7] Performing analysis...  [*******]                                                      (156.8s @ 3.03GB)
+    15,660 (91.30%) of 17,153 classes reachable
+    23,895 (66.64%) of 35,857 fields reachable
+    81,149 (65.27%) of 124,321 methods reachable
+        919 classes,   268 fields, and 4,426 methods registered for reflection
         63 classes,    68 fields, and    55 methods registered for JNI access
         4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                    (24.9s @ 1.39GB)
-    [4/7] Parsing methods...      [****]                                                          (18.8s @ 2.18GB)
-    [5/7] Inlining methods...     [***]                                                           (10.0s @ 2.19GB)
-    [6/7] Compiling methods...    [*********]                                                     (78.5s @ 2.52GB)
-    [7/7] Creating image...                                                                       (12.8s @ 2.62GB)
-    24.86MB (47.56%) for code area:    56,234 compilation units
-    27.10MB (51.84%) for image heap:  378,650 objects and 366 resources
-    319.96KB ( 0.60%) for other data
+    [3/7] Building universe...                                                                    (26.2s @ 1.15GB)
+    [4/7] Parsing methods...      [*****]                                                         (23.5s @ 2.01GB)
+    [5/7] Inlining methods...     [***]                                                           (12.4s @ 2.12GB)
+    [6/7] Compiling methods...    [********]                                                      (71.8s @ 2.37GB)
+    [7/7] Creating image...                                                                       (12.6s @ 2.49GB)
+    24.86MB (47.56%) for code area:    56,213 compilation units
+    27.10MB (51.84%) for image heap:  378,545 objects and 366 resources
+    319.38KB ( 0.60%) for other data
     52.27MB in total
     --------------------------------------------------------------------------------------------------------------
     Top 10 packages in code area:                          Top 10 object types in image heap:
     1.98MB com.oracle.svm.core.code                        5.69MB byte[] for code metadata
     1.18MB sun.security.ssl                                3.47MB byte[] for java.lang.String
-    823.17KB java.util                                       3.35MB byte[] for embedded resources
-    545.10KB org.apache.catalina.core                        2.72MB java.lang.Class
-    499.62KB org.apache.tomcat.util.net                      2.66MB java.lang.String
-    489.50KB org.apache.coyote.http2                         2.36MB byte[] for general heap data
-    465.22KB com.sun.crypto.provider                       944.71KB byte[] for reflection metadata
-    438.77KB java.lang.invoke                              734.34KB com.oracle.svm.core.hub.DynamicHubCompanion
-    417.30KB java.text                                     446.09KB c.o.s.core.hub.DynamicHub$ReflectionMetadata
-    361.50KB sun.nio.ch                                    409.34KB java.util.concurrent.ConcurrentHashMap$Node
-    17.36MB for 666 more packages                           3.61MB for 3246 more object types
+    824.27KB java.util                                       3.35MB byte[] for embedded resources
+    545.81KB org.apache.catalina.core                        2.72MB java.lang.Class
+    499.69KB org.apache.tomcat.util.net                      2.66MB java.lang.String
+    490.02KB org.apache.coyote.http2                         2.36MB byte[] for general heap data
+    465.23KB com.sun.crypto.provider                       944.23KB byte[] for reflection metadata
+    438.78KB java.lang.invoke                              734.06KB com.oracle.svm.core.hub.DynamicHubCompanion
+    417.30KB java.text                                     445.91KB c.o.s.core.hub.DynamicHub$ReflectionMetadata
+    361.50KB sun.nio.ch                                    409.16KB java.util.concurrent.ConcurrentHashMap$Node
+    17.36MB for 666 more packages                           3.62MB for 3246 more object types
     --------------------------------------------------------------------------------------------------------------
-                    18.6s (5.5% of total time) in 42 GCs | Peak RSS: 4.32GB | CPU load: 1.75
+                    19.1s (5.8% of total time) in 42 GCs | Peak RSS: 4.36GB | CPU load: 1.74
     --------------------------------------------------------------------------------------------------------------
     Produced artifacts:
-    /home/sachin_pik/graalvmee-spring-native-image/spring-native-image/target/jibber (executable)
-    /home/sachin_pik/graalvmee-spring-native-image/spring-native-image/target/jibber.build_artifacts.txt (txt)
+    /home/graal_user/spring-native-image/target/jibber (executable)
+    /home/graal_user/spring-native-image/target/jibber.build_artifacts.txt (txt)
     ==============================================================================================================
-    Finished generating 'jibber' in 5m 34s.
+    Finished generating 'jibber' in 5m 30s.
     ...
     ```
 


### PR DESCRIPTION
Cloud Shell has upgraded the JDK and GraalVM versions.
Also, I have updated Micronaut to 3.7.1

@olyagpl - can you please approve and merge the change? I have already tested the changes in Cloud Shell.