### PR TITLE
Enable Native Image build reports for some demos.

### DIFF
--- a/.github/workflows/espresso-jshell.yml
+++ b/.github/workflows/espresso-jshell.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/fortune-demo.yml
+++ b/.github/workflows/fortune-demo.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/functionGraphDemo.yml
+++ b/.github/workflows/functionGraphDemo.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/graalpy-notebook-example.yml
+++ b/.github/workflows/graalpy-notebook-example.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/hello-graal.yml
+++ b/.github/workflows/hello-graal.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/hello-graal.yml
+++ b/.github/workflows/hello-graal.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'hello-graal'
@@ -26,6 +27,8 @@ jobs:
           java-version: '11'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'hello-graal'
         run: |
           cd hello-graal

--- a/.github/workflows/java-hello-world-maven.yml
+++ b/.github/workflows/java-hello-world-maven.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'latest' # EE dev builds not supported

--- a/.github/workflows/java-hello-world-maven.yml
+++ b/.github/workflows/java-hello-world-maven.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'java-hello-world-maven'
@@ -25,6 +26,8 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'java-hello-world-maven'
         run: |
           cd java-hello-world-maven

--- a/.github/workflows/java-kotlin-aot.yml
+++ b/.github/workflows/java-kotlin-aot.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/java-kotlin-aot.yml
+++ b/.github/workflows/java-kotlin-aot.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'java-kotlin-aot'
@@ -26,6 +27,8 @@ jobs:
           java-version: '11'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'java-kotlin-aot'
         run: |
           cd java-kotlin-aot

--- a/.github/workflows/java-simple-stream-benchmark.yml
+++ b/.github/workflows/java-simple-stream-benchmark.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/java-simple-stream-benchmark.yml
+++ b/.github/workflows/java-simple-stream-benchmark.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'java-simple-stream-benchmark'
@@ -26,6 +27,8 @@ jobs:
           java-version: '11'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'java-simple-stream-benchmark'
         run: |
           cd java-simple-stream-benchmark

--- a/.github/workflows/javagdbnative.yml
+++ b/.github/workflows/javagdbnative.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/javagdbnative.yml
+++ b/.github/workflows/javagdbnative.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'javagdbnative'
@@ -27,6 +28,8 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'javagdbnative'
         run: |
           cd javagdbnative

--- a/.github/workflows/js-java-async-helidon.yml
+++ b/.github/workflows/js-java-async-helidon.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/micronaut-hello-rest-maven.yml
+++ b/.github/workflows/micronaut-hello-rest-maven.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'latest' # EE dev builds not supported

--- a/.github/workflows/micronaut-hello-rest-maven.yml
+++ b/.github/workflows/micronaut-hello-rest-maven.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'micronaut-hello-rest-maven'
@@ -25,6 +26,8 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'micronaut-hello-rest-maven'
         run: |
           cd micronaut-hello-rest-maven

--- a/.github/workflows/multithreading-demo.yml
+++ b/.github/workflows/multithreading-demo.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/native-hello-module.yml
+++ b/.github/workflows/native-hello-module.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/native-hello-module.yml
+++ b/.github/workflows/native-hello-module.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'native-hello-module'
@@ -27,6 +28,8 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'native-hello-module'
         run: |
           cd native-hello-module

--- a/.github/workflows/native-image-configure-examples.yml
+++ b/.github/workflows/native-image-configure-examples.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/native-list-dir.yml
+++ b/.github/workflows/native-list-dir.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'native-list-dir'
@@ -26,6 +27,8 @@ jobs:
           java-version: '11'
           components: 'native-image,js'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'native-list-dir'
         run: |
           cd native-list-dir

--- a/.github/workflows/native-list-dir.yml
+++ b/.github/workflows/native-list-dir.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/native-netty-plot.yml
+++ b/.github/workflows/native-netty-plot.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'native-netty-plot'
@@ -27,6 +28,8 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'native-netty-plot'
         run: |
           cd native-netty-plot

--- a/.github/workflows/native-netty-plot.yml
+++ b/.github/workflows/native-netty-plot.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/polyglot-chat-app.yml
+++ b/.github/workflows/polyglot-chat-app.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/polyglot-debug.yml
+++ b/.github/workflows/polyglot-debug.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/polyglot-javascript-java-r.yml
+++ b/.github/workflows/polyglot-javascript-java-r.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/spring-native-image.yml
+++ b/.github/workflows/spring-native-image.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'dev'

--- a/.github/workflows/spring-native-image.yml
+++ b/.github/workflows/spring-native-image.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'spring-native-graal'
@@ -27,6 +28,8 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'spring-native-image'
         run: |
           cd spring-native-image

--- a/.github/workflows/spring-r.yml
+++ b/.github/workflows/spring-r.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: '22.1.0'

--- a/.github/workflows/streams.yml
+++ b/.github/workflows/streams.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'latest' # EE dev builds not supported

--- a/.github/workflows/streams.yml
+++ b/.github/workflows/streams.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  pull-requests: write # for `native-image-pr-reports` option
 jobs:
   run:
     name: Run 'streams'
@@ -24,6 +25,8 @@ jobs:
           java-version: '11'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
       - name: Run 'streams'
         run: |
           cd streams

--- a/.github/workflows/tiny-java-containers.yml
+++ b/.github/workflows/tiny-java-containers.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'latest' # EE dev builds not supported


### PR DESCRIPTION
See job summaries and PR comments below.

(I've only enabled build reports for all demos that build a single native executable/shared library).