### PR TITLE
Updated JDK versions in Cloud Shell/Code Editor

### DIFF
--- a/_common/README-check-version-env-vars.md
+++ b/_common/README-check-version-env-vars.md
@@ -6,12 +6,12 @@
     csruntimectl java list
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+    * graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+      oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Confirm the environment variable `JAVA_HOME` is set correctly:
@@ -44,12 +44,12 @@
     java -version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    java version "17.0.4.1" 2022-08-18 LTS
-    Java(TM) SE Runtime Environment GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08)
-    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08, mixed mode, sharing)s
+    java version "17.0.5" 2022-10-18 LTS
+    Java(TM) SE Runtime Environment GraalVM EE 22.3.0 (build 17.0.5+9-LTS-jvmci-22.3-b07)
+    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.3.0 (build 17.0.5+9-LTS-jvmci-22.3-b07, mixed mode, sharing)
     ```
 
 5. Confirm the `native-image` version:
@@ -58,10 +58,10 @@
     native-image --version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    GraalVM 22.2.0.1 Java 17 EE (Java Version 17.0.4.1+1-LTS-jvmci-22.2-b08)
+    GraalVM 22.3.0 Java 17 EE (Java Version 17.0.5+9-LTS-jvmci-22.3-b07)
     ```
 
 6. Confirm the `Java` used for Maven builds:
@@ -70,11 +70,11 @@
     mvn --version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
     ...
-    Java version: 17.0.4.1, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
+    Java version: 17.0.5, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
     ...
     ```
 

--- a/java-hello-world-maven/README-Cloud-Shell.md
+++ b/java-hello-world-maven/README-Cloud-Shell.md
@@ -29,21 +29,21 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     The output should be similar to:
 
     ```shell
-      graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-    * openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+      graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+    * oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4.1
+    csruntimectl java set graalvmeejdk-17
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.1.
+    The current managed java version is set to graalvmeejdk-17.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables
@@ -106,64 +106,7 @@ You will notice the `Quick Build` mode reduces the time required to generate a n
 2. Use the Native Image maven plugin to create a native executable:
 
     ```shell
-    export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
-
     mvn clean -Pnative -DskipTests package
-
-    ```
-
-    With **Quick Build enabled** in the pom.xml, the output should be similar to:
-
-    ```
-    ...
-    You enabled -Ob for this image build. This will configure some optimizations to reduce image build time.
-    ...
-    ========================================================================================================================
-    GraalVM Native Image: Generating 'my-app' (executable)...
-    ========================================================================================================================
-    [1/7] Initializing...                                                                                   (10.7s @ 0.21GB)
-    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
-    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
-    C compiler: gcc (redhat, x86_64, 11.2.1)
-    Garbage collector: Serial GC
-    [2/7] Performing analysis...  [*****]                                                                   (20.4s @ 0.68GB)
-    1,819 (62.34%) of  2,918 classes reachable
-    1,662 (46.88%) of  3,545 fields reachable
-    7,638 (37.13%) of 20,569 methods reachable
-        17 classes,     0 fields, and   254 methods registered for reflection
-        49 classes,    32 fields, and    48 methods registered for JNI access
-        4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                               (3.0s @ 0.93GB)
-    [4/7] Parsing methods...      [**]                                                                       (2.7s @ 0.36GB)
-    [5/7] Inlining methods...     [***]                                                                      (1.9s @ 0.60GB)
-    [6/7] Compiling methods...    [***]                                                                     (11.0s @ 0.72GB)
-    [7/7] Creating image...                                                                                  (1.9s @ 0.91GB)
-    1.78MB (42.86%) for code area:     4,433 compilation units
-    2.23MB (53.52%) for image heap:   36,677 objects and 1 resources
-    154.55KB ( 3.63%) for other data
-    4.16MB in total
-    ------------------------------------------------------------------------------------------------------------------------
-    Top 10 packages in code area:                               Top 10 object types in image heap:
-    208.78KB com.oracle.svm.jni                                 373.80KB byte[] for code metadata
-    184.72KB java.lang                                          316.52KB byte[] for java.lang.String
-    168.31KB com.oracle.svm.core.code                           267.37KB java.lang.Class
-    144.00KB java.util                                          263.25KB java.lang.String
-    104.52KB com.oracle.svm.core.genscavenge                    213.14KB byte[] for general heap data
-    80.73KB java.util.concurrent                               111.71KB char[]
-    64.87KB java.lang.invoke                                    71.05KB com.oracle.svm.core.hub.DynamicHubCompanion
-    52.95KB java.math                                           68.35KB byte[] for reflection metadata
-    44.58KB com.oracle.svm.jni.functions                        50.34KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
-    40.68KB java.io                                             44.95KB java.util.HashMap$Node[]
-    700.72KB for 99 more packages                               346.14KB for 478 more object types
-    ------------------------------------------------------------------------------------------------------------------------
-                            1.5s (2.7% of total time) in 14 GCs | Peak RSS: 1.65GB | CPU load: 1.77
-    ------------------------------------------------------------------------------------------------------------------------
-    Produced artifacts:
-    /home/user_graal/java-hello-world-maven/target/my-app (executable)
-    /home/user_graal/java-hello-world-maven/target/my-app.build_artifacts.txt (txt)
-    ========================================================================================================================
-    Finished generating 'my-app' in 53.5s.
-    ...
     ```
 
 3. Run the native executable using:
@@ -189,62 +132,7 @@ You will notice the `Quick Build` mode reduces the time required to generate a n
 2. Use the Native Image maven plugin to create a native executable:
 
     ```shell
-    export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
-
     mvn clean -Pnative -DskipTests package
-    
-    ```
-
-    With **Quick Build disabled** in the pom.xml, the output should be similar to:
-
-    ```
-    ...
-    ========================================================================================================================
-    GraalVM Native Image: Generating 'my-app' (executable)...
-    ========================================================================================================================
-    [1/7] Initializing...                                                                                   (10.8s @ 0.23GB)
-    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
-    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
-    C compiler: gcc (redhat, x86_64, 11.2.1)
-    Garbage collector: Serial GC
-    [2/7] Performing analysis...  [*****]                                                                   (20.2s @ 0.69GB)
-    1,858 (61.54%) of  3,019 classes reachable
-    1,698 (47.23%) of  3,595 fields reachable
-    7,633 (36.19%) of 21,092 methods reachable
-        17 classes,     0 fields, and   254 methods registered for reflection
-        49 classes,    32 fields, and    48 methods registered for JNI access
-        4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                               (3.0s @ 0.95GB)
-    [4/7] Parsing methods...      [**]                                                                       (2.9s @ 0.39GB)
-    [5/7] Inlining methods...     [***]                                                                      (1.5s @ 0.64GB)
-    [6/7] Compiling methods...    [******]                                                                  (44.7s @ 2.12GB)
-    [7/7] Creating image...                                                                                  (2.1s @ 2.34GB)
-    2.50MB (49.19%) for code area:     3,714 compilation units
-    2.43MB (47.88%) for image heap:   36,993 objects and 1 resources
-    152.23KB ( 2.92%) for other data
-    5.08MB in total
-    ------------------------------------------------------------------------------------------------------------------------
-    Top 10 packages in code area:                               Top 10 object types in image heap:
-    299.87KB java.lang                                          508.50KB byte[] for code metadata
-    193.82KB com.oracle.svm.jni                                 319.17KB byte[] for java.lang.String
-    190.77KB java.util                                          272.45KB java.lang.Class
-    155.80KB com.oracle.svm.core.code                           265.22KB java.lang.String
-    118.87KB com.oracle.svm.core.genscavenge                    214.75KB byte[] for general heap data
-    111.79KB java.util.concurrent                               111.71KB char[]
-    75.68KB java.lang.invoke                                    72.58KB com.oracle.svm.core.hub.DynamicHubCompanion
-    73.33KB java.math                                           69.43KB byte[] for reflection metadata
-    71.31KB jdk.proxy4                                          51.22KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
-    68.17KB com.oracle.svm.core                                 44.95KB java.util.HashMap$Node[]
-    1.15MB for 96 more packages                               348.99KB for 474 more object types
-    ------------------------------------------------------------------------------------------------------------------------
-                            1.5s (1.7% of total time) in 17 GCs | Peak RSS: 2.94GB | CPU load: 1.76
-    ------------------------------------------------------------------------------------------------------------------------
-    Produced artifacts:
-    /home/user_graal/java-hello-world-maven/target/my-app (executable)
-    /home/user_graal/java-hello-world-maven/target/my-app.build_artifacts.txt (txt)
-    ========================================================================================================================
-    Finished generating 'my-app' in 1m 28s.
-    ...
     ```
 
 3. Run the native executable using:

--- a/micronaut-hello-rest-maven/README-Cloud-Shell.md
+++ b/micronaut-hello-rest-maven/README-Cloud-Shell.md
@@ -32,24 +32,24 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     csruntimectl java list
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+      graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+    * oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4.1
+    csruntimectl java set graalvmeejdk-17
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.1.
+    The current managed java version is set to graalvmeejdk-17.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables
@@ -133,65 +133,6 @@ Use GraalVM Native Image to produce a native executable.
 
     ```shell
     ./mvnw package -Dpackaging=native-image
-    ```
-    
-    The output should be similar to:
-    
-    ```shell
-    ...
-    You enabled -Ob for this image build. This will configure some optimizations to reduce image build time.
-    ...
-    ========================================================================================================================
-    GraalVM Native Image: Generating 'MnHelloRest' (executable)...
-    ========================================================================================================================
-    [1/7] Initializing...                                                                                   (14.1s @ 0.15GB)
-    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
-    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
-    C compiler: gcc (redhat, x86_64, 11.2.1)
-    Garbage collector: Serial GC
-    4 user-specific feature(s)
-    - io.micronaut.buffer.netty.NettyFeature
-    - io.micronaut.core.graal.ServiceLoaderFeature
-    - io.micronaut.http.netty.graal.HttpNettyFeature
-    - io.micronaut.jackson.JacksonDatabindFeature
-    [2/7] Performing analysis...  [*********]                                                              (146.6s @ 2.75GB)
-    13,627 (91.99%) of 14,814 classes reachable
-    18,736 (56.89%) of 32,931 fields reachable
-    73,543 (63.74%) of 115,373 methods reachable
-        749 classes,   342 fields, and 2,783 methods registered for reflection
-        63 classes,    68 fields, and    55 methods registered for JNI access
-        4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                              (26.1s @ 2.75GB)
-    [4/7] Parsing methods...      [******]                                                                  (33.1s @ 2.17GB)
-    [5/7] Inlining methods...     [***]                                                                     (10.1s @ 1.72GB)
-    [6/7] Compiling methods...    [********]                                                                (66.3s @ 2.49GB)
-    [7/7] Creating image...                                                                                 (14.1s @ 2.12GB)
-    19.92MB (47.42%) for code area:    52,012 compilation units
-    21.77MB (51.81%) for image heap:  340,805 objects and 292 resources
-    331.24KB ( 0.77%) for other data
-    42.02MB in total
-    ------------------------------------------------------------------------------------------------------------------------
-    Top 10 packages in code area:                               Top 10 object types in image heap:
-    1.83MB com.oracle.svm.core.code                             4.60MB byte[] for code metadata
-    1.18MB sun.security.ssl                                     3.00MB byte[] for java.lang.String
-    750.93KB java.util                                            2.93MB java.lang.Class
-    465.06KB com.sun.crypto.provider                              2.21MB java.lang.String
-    424.19KB java.lang.invoke                                     2.06MB byte[] for general heap data
-    407.29KB java.text                                          764.93KB byte[] for reflection metadata
-    406.78KB io.netty.buffer                                    638.77KB com.oracle.svm.core.hub.DynamicHubCompanion
-    386.12KB reactor.core.publisher                             407.97KB java.util.concurrent.ConcurrentHashMap$Node
-    372.08KB java.lang                                          392.13KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
-    364.26KB io.netty.handler.codec.http2                       377.50KB java.util.HashMap$Node
-    13.05MB for 501 more packages                                3.64MB for 3063 more object types
-    ------------------------------------------------------------------------------------------------------------------------
-                            17.3s (5.4% of total time) in 36 GCs | Peak RSS: 4.15GB | CPU load: 1.57
-    ------------------------------------------------------------------------------------------------------------------------
-    Produced artifacts:
-    /home/graal_user/micronaut-hello-rest-maven/target/MnHelloRest (executable)
-    /home/graal_user/micronaut-hello-rest-maven/target/MnHelloRest.build_artifacts.txt (txt)
-    ========================================================================================================================
-    Finished generating 'MnHelloRest' in 5m 18s.
-    ...    
     ```
     
 2. Run the app native executable in the background

--- a/micronaut-hello-rest-maven/pom.xml
+++ b/micronaut-hello-rest-maven/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>io.micronaut</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <version>3.7.1</version>
+    <version>3.7.3</version>
   </parent>
 
   <properties>
     <packaging>jar</packaging>
     <jdk.version>17</jdk.version>
     <release.version>17</release.version>
-    <micronaut.version>3.7.1</micronaut.version>
+    <micronaut.version>3.7.3</micronaut.version>
     <micronaut.runtime>netty</micronaut.runtime>
     <exec.mainClass>com.example.Application</exec.mainClass>
   </properties>

--- a/spring-native-image/README-Cloud-Shell.md
+++ b/spring-native-image/README-Cloud-Shell.md
@@ -122,7 +122,7 @@ Let's build a native executable for our Spring Boot microservice using GraalVM E
 1. Build the app native executable
 
     ```shell
-    mvn package native:compile -Pnative 
+    mvn -Pnative native:compile
     ```
     
     This will create a binary executable `target/benchmark-jibber`.

--- a/spring-native-image/README-Cloud-Shell.md
+++ b/spring-native-image/README-Cloud-Shell.md
@@ -117,8 +117,7 @@ This step is optional - [Check software version and environment variables](../_c
 
 ## Step 5: Build and run a native executable
 
-Let's build a native executable for our Spring Boot microservice using GraalVM Enterprise Native Image. In this example, we'll use the Maven plugin from [GraalVM Native Build Tools](https://graalvm.github.io/native-build-tools/latest/index.html) and
-[Spring Native](https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/).
+Let's build a native executable for our Spring Boot microservice using GraalVM Enterprise Native Image.
 
 1. Build the app native executable
 

--- a/spring-native-image/README-Cloud-Shell.md
+++ b/spring-native-image/README-Cloud-Shell.md
@@ -125,12 +125,12 @@ Let's build a native executable for our Spring Boot microservice using GraalVM E
     mvn package native:compile -Pnative 
     ```
     
-    This will create a binary executable `target/jibber`.
+    This will create a binary executable `target/benchmark-jibber`.
 
 2. Run the app native executable in the background
 
     ```shell
-    ./target/jibber &
+    ./target/benchmark-jibber &
     ```
 
 3. Test the app native executable

--- a/spring-native-image/README-Cloud-Shell.md
+++ b/spring-native-image/README-Cloud-Shell.md
@@ -26,24 +26,24 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     csruntimectl java list
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+      graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+    * oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4.1
+    csruntimectl java set graalvmeejdk-17
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.1.
+    The current managed java version is set to graalvmeejdk-17.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables
@@ -123,10 +123,7 @@ Let's build a native executable for our Spring Boot microservice using GraalVM E
 1. Build the app native executable
 
     ```shell
-    export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
-
-    mvn package -Dnative
-
+    mvn package native:compile -Pnative 
     ```
     
     This will create a binary executable `target/jibber`.

--- a/spring-native-image/README-Code-Editor.md
+++ b/spring-native-image/README-Code-Editor.md
@@ -127,15 +127,15 @@ Let's build a native executable for our Spring Boot microservice using GraalVM E
 1. Build the app native executable
 
     ```shell
-    mvn package native:compile -Pnative
+    mvn -Pnative native:compile
     ```
     
-    This will create a binary executable `target/jibber`. 
+    This will create a binary executable `target/benchmark-jibber`. 
 
 2. Run the app native executable in the background
 
     ```shell
-    ./target/jibber &
+    ./target/benchmark-jibber &
     ```
 
 3. Test the app native executable

--- a/spring-native-image/README-Code-Editor.md
+++ b/spring-native-image/README-Code-Editor.md
@@ -122,8 +122,7 @@ This step is optional - [Check software version and environment variables](../_c
 
 ## Step 5: Build and run a native executable
 
-Let's build a native executable for our Spring Boot microservice using GraalVM Enterprise Native Image. In this example, we'll use the Maven plugin from [GraalVM Native Build Tools](https://graalvm.github.io/native-build-tools/latest/index.html) and
-[Spring Native](https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/).
+Let's build a native executable for our Spring Boot microservice using GraalVM Enterprise Native Image.
 
 1. Build the app native executable
 

--- a/spring-native-image/README-Code-Editor.md
+++ b/spring-native-image/README-Code-Editor.md
@@ -30,24 +30,24 @@ GraalVM Enterprise JDK 17 and Native Image are preinstalled in Cloud Shell, so y
     csruntimectl java list
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+      graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+    * oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4.1
+    csruntimectl java set graalvmeejdk-17
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.1.
+    The current managed java version is set to graalvmeejdk-17.
     ```
 
 ## Step 3: [OPTIONAL] Confirm software version and environment variables
@@ -128,73 +128,10 @@ Let's build a native executable for our Spring Boot microservice using GraalVM E
 1. Build the app native executable
 
     ```shell
-    export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
-
-    mvn package -Dnative
-
+    mvn package native:compile -Pnative
     ```
     
-    This will create a binary executable `target/jibber`. The output should be similar to:
-
-    ```shell
-    ...
-    You enabled -Ob for this image build. This will configure some optimizations to reduce image build time.
-    ...
-    ==============================================================================================================
-    GraalVM Native Image: Generating 'jibber' (executable)...
-    ==============================================================================================================
-    Warning: Could not register org.springframework.boot.actuate.health.ReactiveHealthEndpointWebExtension: allPublicMethods for reflection. Reason: java.lang.NoClassDefFoundError: reactor/core/publisher/Mono.
-    Warning: Could not register org.springframework.boot.autoconfigure.jdbc.HikariDriverConfigurationFailureAnalyzer: allDeclaredConstructors for reflection. Reason: java.lang.NoClassDefFoundError: org/springframework/jdbc/CannotGetJdbcConnectionException.
-    Warning: Could not register org.springframework.boot.diagnostics.analyzer.ValidationExceptionFailureAnalyzer: allDeclaredConstructors for reflection. Reason: java.lang.NoClassDefFoundError: javax/validation/ValidationException.
-    Warning: Could not register org.springframework.boot.liquibase.LiquibaseChangelogMissingFailureAnalyzer: allDeclaredConstructors for reflection. Reason: java.lang.NoClassDefFoundError: liquibase/exception/ChangeLogParseException.
-    [1/7] Initializing...                                                                         (16.9s @ 0.29GB)
-    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
-    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
-    C compiler: gcc (redhat, x86_64, 11.2.1)
-    Garbage collector: Serial GC
-    1 user-specific feature(s)
-    - com.oracle.svm.thirdparty.gson.GsonFeature
-    The bundle named: org.apache.tomcat.util.threads.res.LocalStrings, has not been found. If the bundle is part of a module, verify the bundle name is a fully qualified class name. Otherwise verify the bundle path is accessible in the classpath.
-    Warning: Could not register complete reflection metadata for org.springframework.validation.beanvalidation.SpringValidatorAdapter$ViolationFieldError. Reason(s): java.lang.NoClassDefFoundError: javax/validation/Validator
-    [2/7] Performing analysis...  [*******]                                                      (156.8s @ 3.03GB)
-    15,660 (91.30%) of 17,153 classes reachable
-    23,895 (66.64%) of 35,857 fields reachable
-    81,149 (65.27%) of 124,321 methods reachable
-        919 classes,   268 fields, and 4,426 methods registered for reflection
-        63 classes,    68 fields, and    55 methods registered for JNI access
-        4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                    (26.2s @ 1.15GB)
-    [4/7] Parsing methods...      [*****]                                                         (23.5s @ 2.01GB)
-    [5/7] Inlining methods...     [***]                                                           (12.4s @ 2.12GB)
-    [6/7] Compiling methods...    [********]                                                      (71.8s @ 2.37GB)
-    [7/7] Creating image...                                                                       (12.6s @ 2.49GB)
-    24.86MB (47.56%) for code area:    56,213 compilation units
-    27.10MB (51.84%) for image heap:  378,545 objects and 366 resources
-    319.38KB ( 0.60%) for other data
-    52.27MB in total
-    --------------------------------------------------------------------------------------------------------------
-    Top 10 packages in code area:                          Top 10 object types in image heap:
-    1.98MB com.oracle.svm.core.code                        5.69MB byte[] for code metadata
-    1.18MB sun.security.ssl                                3.47MB byte[] for java.lang.String
-    824.27KB java.util                                       3.35MB byte[] for embedded resources
-    545.81KB org.apache.catalina.core                        2.72MB java.lang.Class
-    499.69KB org.apache.tomcat.util.net                      2.66MB java.lang.String
-    490.02KB org.apache.coyote.http2                         2.36MB byte[] for general heap data
-    465.23KB com.sun.crypto.provider                       944.23KB byte[] for reflection metadata
-    438.78KB java.lang.invoke                              734.06KB com.oracle.svm.core.hub.DynamicHubCompanion
-    417.30KB java.text                                     445.91KB c.o.s.core.hub.DynamicHub$ReflectionMetadata
-    361.50KB sun.nio.ch                                    409.16KB java.util.concurrent.ConcurrentHashMap$Node
-    17.36MB for 666 more packages                           3.62MB for 3246 more object types
-    --------------------------------------------------------------------------------------------------------------
-                    19.1s (5.8% of total time) in 42 GCs | Peak RSS: 4.36GB | CPU load: 1.74
-    --------------------------------------------------------------------------------------------------------------
-    Produced artifacts:
-    /home/graal_user/spring-native-image/target/jibber (executable)
-    /home/graal_user/spring-native-image/target/jibber.build_artifacts.txt (txt)
-    ==============================================================================================================
-    Finished generating 'jibber' in 5m 30s.
-    ...
-    ```
+    This will create a binary executable `target/jibber`. 
 
 2. Run the app native executable in the background
 

--- a/spring-native-image/README.md
+++ b/spring-native-image/README.md
@@ -64,7 +64,7 @@ To build the native executable version of the application:
 
 ```shell
 # The -Pnative profile is used to turn on building a native executable within the maven file
-mvn package native:compile -Pnative 
+mvn -Pnative native:compile
 ```
 
 This will create a binary executable `target/benchmark-jibber`. You can run this and test it in the same way as we did the Java application:

--- a/spring-native-image/README.md
+++ b/spring-native-image/README.md
@@ -67,8 +67,7 @@ To build the native executable version of the application:
 mvn package native:compile -Pnative 
 ```
 
-This will create a binary executable `target/jibber`. You can run this and test it in the same way as we did the Java
-application:
+This will create a binary executable `target/benchmark-jibber`. You can run this and test it in the same way as we did the Java application:
 
 ```shell
 ./target/benchmark-jibber &


### PR DESCRIPTION
**Changes:**
1. Updated JDK versions in Cloud Shell/Code Editor
2. Using Micronaut 3.7.3
3. Updated native executable name
4. Update maven native build command to "mvn -Pnative native:compile" as per https://docs.spring.io/spring-boot/docs/3.0.0-RC1/reference/html/native-image.html#native-image.developing-your-first-application.native-build-tools.maven