### PR TITLE
update maven, app name, mvn command

### DIFF
--- a/spring-native-image/Dockerfiles/Dockerfile
+++ b/spring-native-image/Dockerfiles/Dockerfile
@@ -13,8 +13,8 @@ RUN microdnf update \
 # 1) https://github.com/carlossg/docker-maven/blob/925e49a1d0986070208e3c06a11c41f8f2cada82/openjdk-17/Dockerfile
 # 2) https://maven.apache.org/download.cgi
 ARG USER_HOME_DIR="/root"
-ARG SHA=89ab8ece99292476447ef6a6800d9842bbb60787b9b8a45c103aa61d2f205a971d8c3ddfb8b03e514455b4173602bd015e82958c0b3ddc1728a57126f773c743
-ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.tar.gz
+ARG SHA=f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
+ARG MAVEN_DOWNLOAD_URL=https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_DOWNLOAD_URL} \
@@ -33,7 +33,7 @@ WORKDIR /build
 COPY . /build
 
 # Build
-RUN mvn --no-transfer-progress clean package -Pnative
+RUN mvn --no-transfer-progress clean native:compile -Pnative
 
 # The deployment Image
 FROM docker.io/oraclelinux:8-slim
@@ -41,5 +41,5 @@ FROM docker.io/oraclelinux:8-slim
 EXPOSE 8080
 
 # Copy the native executable into the containers
-COPY --from=builder /build/target/jibber .
-ENTRYPOINT ["/jibber"]
+COPY --from=builder /build/target/benchmark-jibber .
+ENTRYPOINT ["/benchmark-jibber"]


### PR DESCRIPTION
Hi
the dockerfile isan´t working
- mvn url was invalid, i solved adding the new 3.8.6
- the comand mvn package is not working for me too and i change for native:compile
- the application name was wrong "jibber" but the real generated name is "benchmark-jibber" so i changed in de COPY and ENTRYPOINT

with this changes worked fine