### PR TITLE
[GR-41947] Avoid optional AWT dependency in the espresso-jshell demo.

### DIFF
--- a/.github/workflows/espresso-jshell.yml
+++ b/.github/workflows/espresso-jshell.yml
@@ -18,12 +18,19 @@ jobs:
     name: Run 'espresso-jshell'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        include:
+          - version: 'latest'
+            java-version: '17'
+          - version: 'dev'
+            java-version: 'dev'
     steps:
       - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.2.0' # temporarily locked because demo does not run on 22.3.0+/JDK17+ yet
-          java-version: '11'
+          version: ${{ matrix.version }}
+          java-version: ${{ matrix.java-version }}
           components: 'espresso,native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run 'espresso-jshell'

--- a/espresso-jshell/README.md
+++ b/espresso-jshell/README.md
@@ -41,7 +41,7 @@ For further discussions and questions please join our `#espresso` channel on the
 
 3. To exit the shell, type `/exit`.
 
-The native `espresso-jshell` is not fully standalone, it does not bundle _jars/jmods_ nor the core Java native libraries. `jshell` also needs a `java.home` for the host Java compiler. `espresso-jshell` does not require a full-blown GraalVM distribution to run. It can run with a minimal/jlink-ed `JAVA_HOME` that includes the Espresso home (`$GRAALVM_HOME/languages/java`), mimicking the same folder structure as GraalVM.
+The native `espresso-jshell` is not fully standalone, it does not bundle _jars/jmods_ nor the core Java native libraries. `jshell` also needs a `java.home` for the host Java compiler. `espresso-jshell` does not require a full-blown GraalVM distribution to run. It can run with a minimal/jlink-ed `JAVA_HOME` that includes the Espresso home (`$JAVA_HOME/languages/java`), mimicking the same folder structure as GraalVM.
 
 ## Running `jshell` on Java 8
 

--- a/espresso-jshell/build-espresso-jshell.sh
+++ b/espresso-jshell/build-espresso-jshell.sh
@@ -3,7 +3,6 @@
 # Exit on error
 set -e
 
-# JAVA_HOME="/home/mukel/Desktop/graal/graal/sdk/mxbuild/linux-amd64/GRAALVM_C152252C1A_JAVA11/graalvm-c152252c1a-java11-21.0.0-dev"
 SCRATCH=./out
 
 if [[ -z "$JAVA_HOME" ]]; then
@@ -14,37 +13,40 @@ fi
 echo $JAVA_HOME
 
 # Manually build espresso-jshell.jar, requires GraalVM >= 21.0 with Native Image and Java on Truffle (Espresso) installed.
-echo "1/7 Compiling espresso-jshell..."
+echo "1/8 Compiling espresso-jshell..."
 $JAVA_HOME/bin/javac $(find src/main/java -name '*.java') -d "$SCRATCH"
 
-echo "2/7 Packaging espresso-jshell.jar..."
+echo "2/8 Packaging espresso-jshell.jar..."
 cp -r ./src/main/resources/* "$SCRATCH"
 jar cef com.oracle.truffle.espresso.jshell.JavaShellLauncher espresso-jshell.jar -C "$SCRATCH" .
 
-echo "3/7 Cleaning up scratch folder..."
+echo "3/8 Cleaning up scratch folder..."
 rm -r "$SCRATCH"
 
-echo "4/7 Compiling jshell8..."
+echo "4/8 Compiling jshell8..."
 mkdir -p "$SCRATCH"
 $JAVA_HOME/bin/javac -source 8 -target 8 $(find jshell8 -name '*.java') -d "$SCRATCH"
 
-echo "5/7 Packaging jshell8.jar..."
+echo "5/8 Packaging jshell8.jar..."
 jar cf jshell8.jar -C "$SCRATCH" .
 
-echo "6/7 Cleaning up scratch folder..."
+echo "6/8 Cleaning up scratch folder..."
 rm -r "$SCRATCH"
 
-echo "7/7 Building espresso-jshell native image, this may take a few minutes..."
+echo "7/8 Compiling jdk.editpad-patch..."
+$JAVA_HOME/bin/javac $(find jdk.editpad-patch -name '*.java')
+
+echo "8/8 Building espresso-jshell native image, this may take a few minutes..."
 "$JAVA_HOME/bin/native-image" \
   -H:+AllowJRTFileSystem \
   -H:Name=espresso-jshell \
   --initialize-at-build-time=com.sun.tools.doclint,'jdk.jshell.Snippet$SubKind','com.sun.tools.javac.parser.Tokens$TokenKind' \
   --initialize-at-run-time=com.sun.tools.javac.file.Locations \
-  --report-unsupported-elements-at-runtime \
   -H:ConfigurationFileDirectories=. \
   --language:java \
   -J-Djdk.image.use.jvm.map=false \
   -J--patch-module -Jjdk.jshell=./jdk.jshell-patch `# patch for Java 8, not required for 11` \
+  -J--patch-module -Jjdk.editpad=./jdk.editpad-patch `# avoid optional AWT dependency` \
   -H:+ReportExceptionStackTraces \
   $@ \
   -jar espresso-jshell.jar

--- a/espresso-jshell/jdk.editpad-patch/jdk/editpad/EditPadProvider.java
+++ b/espresso-jshell/jdk.editpad-patch/jdk/editpad/EditPadProvider.java
@@ -1,0 +1,6 @@
+package jdk.editpad;
+
+// Patched to purge the AWT optional dependency from jshell.
+// Note: --patch-module cannot "patch" existing module-info.class, so the (editor) provider is nop-ed instead.
+abstract class EditPadProvider {
+}

--- a/espresso-jshell/src/main/java/com/oracle/truffle/espresso/jshell/JavaShellLauncher.java
+++ b/espresso-jshell/src/main/java/com/oracle/truffle/espresso/jshell/JavaShellLauncher.java
@@ -48,16 +48,16 @@ public final class JavaShellLauncher {
      * The following sources are checked:
      * <ul type=1>
      * <li>{@code org.graalvm.home} property
-     * <li>{@code GRAALVM_HOME} environment variable
+     * <li>{@code JAVA_HOME} environment variable
      * <li>{@code HomeFinder.getInstance().getHomeFolder()}
      * </ul>
      */
     private static void findJavaHome() {
         String javaHome = System.getProperty("java.home");
         if (javaHome == null) {
-            System.err.println("java.home (required by javac) is not defined; trying fallback to 'org.graalvm.home' and $GRAALVM_HOME");
+            System.err.println("java.home (required by javac) is not defined; trying fallback to 'org.graalvm.home' and $JAVA_HOME");
             if (System.getProperty("org.graalvm.home") == null) {
-                String envVariable = System.getenv("GRAALVM_HOME");
+                String envVariable = System.getenv("JAVA_HOME");
                 if (envVariable != null) {
                     System.err.println("Setting org.graalvm.home=" + envVariable);
                     System.setProperty("org.graalvm.home", envVariable);
@@ -68,7 +68,7 @@ public final class JavaShellLauncher {
                 System.err.println("Setting java.home=" + graalvmHome);
                 System.setProperty("java.home", graalvmHome.toString());
             } else {
-                System.err.println("Cannot find GraalVM home; 'org.graalvm.home' nor $GRAALVM_HOME are defined.");
+                System.err.println("Cannot find GraalVM home; 'org.graalvm.home' nor $JAVA_HOME are defined.");
                 System.exit(-1);
             }
         }


### PR DESCRIPTION
This PR ensures that AWT is not reachable, fixing the build and runtime issues in the espresso-jshell demo.