### PR TITLE
Upgrade Java+Javascript Embedding Example to GraalVM for JDK 21 (23.1.1)

### DIFF
--- a/.github/workflows/polyglot-debug.yml
+++ b/.github/workflows/polyglot-debug.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        java-version: ['17', 'dev']
+        java-version: ['21', 'dev']
     steps:
       - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
@@ -34,4 +34,4 @@ jobs:
         run: |
           cd polyglot-debug
           mvn --no-transfer-progress clean package
-          java -cp ./target/PolyglotDebug-1.0-SNAPSHOT.jar org.graalvm.demos.PolyglotDebug
+          mvn exec:exec

--- a/polyglot-debug/README.MD
+++ b/polyglot-debug/README.MD
@@ -32,13 +32,12 @@ This sample code helps to demonstrate simplicity of debugging and developing Gra
 
 ## Debug the Application
 
-Working with a polyglot project in VS Code is simple just open this sample.
-It will be working out of the box with VS Code GraalVM extensions.
+Debugging a polyglot application should work out of the box in VS Code with the GraalVM extension.
 
-1. Place breakpoints either in Java or JavaScript code.
+1. Place breakpoints in _PolyglotDebug.java_.
 
 2. To debug the project, go to __Run and Debug__ activity or simply press F5.
 
 3. Choose **Launch Java 8+** as this is the Polyglot debugger provided by the GraalVM extension.
 
-That is, the sample is running under debugger on GraalVM.
+That is, the sample is running using the GraalVM debugger. 

--- a/polyglot-debug/README.MD
+++ b/polyglot-debug/README.MD
@@ -1,23 +1,44 @@
-# GraalVM Java to JavaScript Polyglot Debugging
+# Debugging a Java with JavaScript Embedding Application
 
-This sample code helps to demonstrate simplicity of debugging and developing GraalVM Polyglot applications using __VS Code extensions__.
+This sample code helps to demonstrate simplicity of debugging and developing GraalVM polyglot applications using Visual Studio (VS) Code extensions.
 
 ## Prerequisites
 
-1. VS Code has to be installed.
+1. Install VS Code and launch it.
 2. Then go to VS Code Extensions activity panel and search for _GraalVM Extension Pack_, install it. The GraalVM Extension Pack will install all required extensions.
-3. [Install GraalVM in VS Code](https://www.graalvm.org/latest/tools/vscode/graalvm-extension/#graalvm-installation-wizard): Navigate to Gr activity panel in VS Code and install some of the latest GraalVM __Enterprise Edition__ versions available from the list.
+2. Open Visual Studio Code, navigate to Extensions activity panel in the left-hand side Activity Bar. Search for “GraalVM” in the search field. Find  [GraalVM Tools for Java](https://marketplace.visualstudio.com/items?itemName=oracle-labs-graalvm.graalvm), press Install. Reload will be required.
+3. [Install GraalVM in VS Code](https://www.graalvm.org/latest/tools/vscode/graalvm-extension/#graalvm-installation-wizard): Navigate to Gr activity panel in VS Code and install the latest Oracle GraalVM version available from the list.
 4. Confirm to set this as _Active GraalVM_ for VS Code.
-5. Install the `js` component.
 
-## Debugging the project
+## Build and Run the Application
 
-Working with Polyglot project in VSCode is simple just open this sample.
+1. Open VS Code Terminal. 
+2. Clone the repository and navigate into the `polyglot-debug` directory:
+    ```bash
+    git clone https://github.com/graalvm/graalvm-demos
+    ```
+    ```bash
+    cd graalvm-demos/polyglot-debug
+    ```
+
+3. Build the application using Maven:
+    ```bash
+    mvn clean package
+    ```
+4. Run this application with the following command:
+    ```bash
+    mvn exec:exec
+    ```
+
+## Debug the Application
+
+Working with a polyglot project in VS Code is simple just open this sample.
 It will be working out of the box with VS Code GraalVM extensions.
 
-Place breakpoints either in Java or JavaScript code.
+1. Place breakpoints either in Java or JavaScript code.
 
-To debug the project go to __Run and Debug__ activity or simply press F5.
-Choose **Launch Java 8+** as this is the Polyglot debugger provided by GraalVM extensions.
+2. To debug the project, go to __Run and Debug__ activity or simply press F5.
+
+3. Choose **Launch Java 8+** as this is the Polyglot debugger provided by the GraalVM extension.
 
 That is, the sample is running under debugger on GraalVM.

--- a/polyglot-debug/README.MD
+++ b/polyglot-debug/README.MD
@@ -6,7 +6,7 @@ This sample code helps to demonstrate simplicity of debugging and developing Gra
 
 1. Install VS Code and launch it.
 2. Then go to VS Code Extensions activity panel and search for _GraalVM Extension Pack_, install it. The GraalVM Extension Pack will install all required extensions.
-2. Open Visual Studio Code, navigate to Extensions activity panel in the left-hand side Activity Bar. Search for “GraalVM” in the search field. Find  [GraalVM Tools for Java](https://marketplace.visualstudio.com/items?itemName=oracle-labs-graalvm.graalvm), press Install. Reload will be required.
+2. Open Visual Studio Code, navigate to Extensions activity panel in the left-hand side Activity Bar. Search for “GraalVM” in the search field. Find  [GraalVM Tools for Java](https://marketplace.visualstudio.com/items?itemName=oracle-labs-graalvm.graalvm), press Install. Reload if required.
 3. [Install GraalVM in VS Code](https://www.graalvm.org/latest/tools/vscode/graalvm-extension/#graalvm-installation-wizard): Navigate to Gr activity panel in VS Code and install the latest Oracle GraalVM version available from the list.
 4. Confirm to set this as _Active GraalVM_ for VS Code.
 

--- a/polyglot-debug/pom.xml
+++ b/polyglot-debug/pom.xml
@@ -104,6 +104,12 @@
             <version>${graalvm.version}</version>
             <type>pom</type>
         </dependency>
+        <dependency> 
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>tools</artifactId>
+            <version>${graalvm.version}</version> 
+            <type>pom</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/polyglot-debug/pom.xml
+++ b/polyglot-debug/pom.xml
@@ -3,12 +3,107 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.graalvm.demos</groupId>
     <artifactId>PolyglotDebug</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <graalvm.version>23.1.1</graalvm.version>
     </properties>
-    <name>PolyglotDebug</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.graalvm.demos.PolyglotDebug</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <arguments>
+                                <argument>--module-path</argument>
+                                <!-- automatically creates the modulepath using all project dependencies -->
+                                <modulepath/>
+                                <argument>-m</argument>
+                                <argument>demo/org.graalvm.demos.PolyglotDebug</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>${JAVA_HOME}/bin/java</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>collections</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>word</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency> 
+            <groupId>org.graalvm.polyglot</groupId> 
+            <artifactId>polyglot</artifactId> 
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>js</artifactId>
+            <version>${graalvm.version}</version>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/polyglot-debug/src/main/java/module-info.java
+++ b/polyglot-debug/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module demo {
+	exports org.graalvm.demos;
+	requires org.graalvm.polyglot;
+}

--- a/polyglot-debug/src/main/java/org/graalvm/demos/PolyglotDebug.java
+++ b/polyglot-debug/src/main/java/org/graalvm/demos/PolyglotDebug.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;


### PR DESCRIPTION
1. Extended pom.xml to include _org.graalvm.sdk_, _org.graalvm.polyglot_, _org.graalvm.polyglot.js_, and _org.graalvm.polyglot.tools_ dependencies.
2. Added _module-info.java_ to run this demo from a module path instead of class path. 
3. Added steps in README.md  how to package and run this embedding example with Maven.
4. Updated .github/workflows/polyglot-debug.yml to run on GraalVM for JDK 21.