### PR TITLE
Update GitHub actions to use Node.js 20

### DIFF
--- a/.github/workflows/espresso-jshell.yml
+++ b/.github/workflows/espresso-jshell.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '17'

--- a/.github/workflows/fortune-demo.yml
+++ b/.github/workflows/fortune-demo.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/functionGraphDemo.yml
+++ b/.github/workflows/functionGraphDemo.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           version: '22.3.0'

--- a/.github/workflows/graalpy-notebook-example.yml
+++ b/.github/workflows/graalpy-notebook-example.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/hello-graal.yml
+++ b/.github/workflows/hello-graal.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/java-hello-world-maven.yml
+++ b/.github/workflows/java-hello-world-maven.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '21.0.1'

--- a/.github/workflows/java-kotlin-aot.yml
+++ b/.github/workflows/java-kotlin-aot.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/java-simple-stream-benchmark.yml
+++ b/.github/workflows/java-simple-stream-benchmark.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/javagdbnative.yml
+++ b/.github/workflows/javagdbnative.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['17', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/jmh-binary-tree.yml
+++ b/.github/workflows/jmh-binary-tree.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: graalvm/setup-graalvm@v1
         with:

--- a/.github/workflows/js-java-async-helidon.yml
+++ b/.github/workflows/js-java-async-helidon.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '21'

--- a/.github/workflows/micronaut-hello-rest-maven.yml
+++ b/.github/workflows/micronaut-hello-rest-maven.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '21'

--- a/.github/workflows/multithreading-demo.yml
+++ b/.github/workflows/multithreading-demo.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-aws-fargate.yml
+++ b/.github/workflows/native-aws-fargate.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '17.0.7'

--- a/.github/workflows/native-aws-lambda.yml
+++ b/.github/workflows/native-aws-lambda.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '17.0.7'

--- a/.github/workflows/native-google-cloud-run.yml
+++ b/.github/workflows/native-google-cloud-run.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '17.0.7'

--- a/.github/workflows/native-heapdump-examples.yml
+++ b/.github/workflows/native-heapdump-examples.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-hello-module.yml
+++ b/.github/workflows/native-hello-module.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-image-configure-examples.yml
+++ b/.github/workflows/native-image-configure-examples.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-image-jmx-demo.yml
+++ b/.github/workflows/native-image-jmx-demo.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-image-logging-examples.yml
+++ b/.github/workflows/native-image-logging-examples.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-image-reflection-example.yml
+++ b/.github/workflows/native-image-reflection-example.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-jfr-demo.yml
+++ b/.github/workflows/native-jfr-demo.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-list-dir.yml
+++ b/.github/workflows/native-list-dir.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '21'

--- a/.github/workflows/native-netty-plot.yml
+++ b/.github/workflows/native-netty-plot.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-oci-container-instances.yml
+++ b/.github/workflows/native-oci-container-instances.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '17.0.7'

--- a/.github/workflows/native-shared-library.yml
+++ b/.github/workflows/native-shared-library.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/native-static-images.yml
+++ b/.github/workflows/native-static-images.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}
@@ -43,7 +43,7 @@ jobs:
       matrix:
         java-version: ['17', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/polyglot-chat-app.yml
+++ b/.github/workflows/polyglot-chat-app.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/polyglot-debug.yml
+++ b/.github/workflows/polyglot-debug.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/polyglot-javascript-java-r.yml
+++ b/.github/workflows/polyglot-javascript-java-r.yml
@@ -24,7 +24,7 @@ jobs:
           - version: '22.3.0' # temporarily locked to 22.3.0 due to R
             java-version: '17'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/spring-native-image.yml
+++ b/.github/workflows/spring-native-image.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         java-version: ['21', 'dev']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/spring-r.yml
+++ b/.github/workflows/spring-r.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           version: '22.3.0'

--- a/.github/workflows/streams.yml
+++ b/.github/workflows/streams.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         java-version: ['21']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/tiny-java-containers.yml
+++ b/.github/workflows/tiny-java-containers.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04 # Docker has changed its behavior on Ubuntu 22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: '21'


### PR DESCRIPTION
To eliminate this warning:
_Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/._