### PR TITLE
Remove the arg to generate JSON build output

### DIFF
--- a/java-hello-world-maven/pom.xml
+++ b/java-hello-world-maven/pom.xml
@@ -84,8 +84,6 @@
                 <buildArg>-H:+ReportExceptionStackTraces</buildArg>
                 <!-- For mostly static native image (only on Linux AMD64 systems) -->
                 <!-- <buildArg>-H:+StaticExecutableWithDynamicLibC</buildArg> -->
-                <!-- To generate the Native Image build output JSON (22.3+) -->
-                <buildArg>-H:BuildOutputJSONFile=build.json</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/java-hello-world-maven/pom.xml
+++ b/java-hello-world-maven/pom.xml
@@ -84,6 +84,8 @@
                 <buildArg>-H:+ReportExceptionStackTraces</buildArg>
                 <!-- For mostly static native image (only on Linux AMD64 systems) -->
                 <!-- <buildArg>-H:+StaticExecutableWithDynamicLibC</buildArg> -->
+                <!-- To generate the Native Image build output JSON (22.3+) -->
+                <!-- <buildArg>-H:BuildOutputJSONFile=build.json</buildArg> -->
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
The machine-readable build output in JSON format is designed for use with monitoring tools. The `native-image` tool prints a full build report to the console by default. I think we shouldn't promote that host option. 
