### PR TITLE
Fix typo of 'docker' in doc

### DIFF
--- a/micronaut-hello-rest-gradle/README.md
+++ b/micronaut-hello-rest-gradle/README.md
@@ -165,7 +165,7 @@ docker build . -t hello
 
 The container image that was created is about 94MB, which makes sense because the Alpine with `glibc` base image is about 18MB and your application is about 71MB.
 ```bash
-doker images
+docker images
 ```
 ```sh
 REPOSITORY              TAG                 IMAGE ID            CREATED             SIZE


### PR DESCRIPTION
A small typo addressed in micronaut-hello-rest-gradle/README.md, making it easier to copy and paste.