### PR TITLE
fix (jmh) : Explicitly configure JMH annotation processor in binary-tree benchmark

### DIFF
--- a/jmh/benchmark-binary-tree/pom.xml
+++ b/jmh/benchmark-binary-tree/pom.xml
@@ -84,6 +84,14 @@ THE POSSIBILITY OF SUCH DAMAGE.
                     <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <fork>true</fork>
                 </configuration>
             </plugin>
             <plugin>

--- a/jmh/benchmark-binary-tree/pom.xml
+++ b/jmh/benchmark-binary-tree/pom.xml
@@ -66,12 +66,6 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>${jmh.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Context
Part of our RPMs QA process, When running the binary-tree benchmark demo for our RPM release for newer GraalVM versions , the benchmark demo fails with: 
`Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList`

This occurs because the JMH annotation processor isn't explicitly configured in the Maven build, leading to missing metadata generation required for JMH benchmarks to run.

## Root Cause
The current `pom.xml` relies on implicit annotation processing, which can be unreliable across different build environments and JDK versions. While it might work in some environments where Maven picks up the processor automatically, it fails in other environments.

## Solution
Added explicit configuration for the JMH annotation processor in the maven-compiler-plugin:
