### PR TITLE
 fix (java-simple-benchmark) : Explicitly configure JMH annotation processor in binary-tree benchmark

### DIFF
--- a/java-simple-stream-benchmark/pom.xml
+++ b/java-simple-stream-benchmark/pom.xml
@@ -35,7 +35,7 @@ questions.
     <name>Simple Java stream benchmark</name>
 
     <prerequisites>
-        <maven>4.0</maven>
+        <maven>3.8.8</maven>
     </prerequisites>
 
     <properties>
@@ -51,12 +51,6 @@ questions.
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>${jmh.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -64,11 +58,17 @@ questions.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
##Context
Part of our RPMs QA process, When running the java-simple-benchmark demo for our RPM release for newer GraalVM versions , the benchmark demo fails with:
`Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
`
This PR addresses the issue encountered during the build and execution of the java-simple-stream-benchmark project, where the JMH-generated resource file META-INF/BenchmarkList was missing, leading to runtime errors. The root cause was identified as incorrect Maven configuration and outdated plugin versions that didn't properly support annotation processing for JMH.

##Changes

1. Updated Maven Plugin Versions:

Upgraded the maven-compiler-plugin to version 3.8.1 to ensure compatibility with current Maven configurations and better support for annotation processing.

2. Corrected <prerequisites> Element

3. Enabled Annotation Processing

