### PR TITLE
[GR-60094] Add demo for Optimize Size Using Build Reports guide.

### DIFF
--- a/.github/workflows/native-image-emit-build-report.yml
+++ b/.github/workflows/native-image-emit-build-report.yml
@@ -1,0 +1,33 @@
+name: native-image/emit-build-report
+on:
+  push:
+    paths:
+      - 'native-image/emit-build-report/**'
+      - '.github/workflows/native-image-emit-build-report.yml'
+  pull_request:
+    paths:
+      - 'native-image/emit-build-report/**'
+      - '.github/workflows/native-image-emit-build-report.yml'
+  schedule:
+    - cron: "0 0 1 * *" # run every month
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  run:
+    name: Run 'native-image/emit-build-report'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '24-ea'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: 'maven'
+          native-image-job-reports: 'true'
+      - name: Run 'native-image/emit-build-report'
+        run: |
+          cd native-image/emit-build-report
+          ./run.sh

--- a/native-image/emit-build-report/.gitignore
+++ b/native-image/emit-build-report/.gitignore
@@ -1,0 +1,3 @@
+.class
+ithword-build-report.html
+ithword

--- a/native-image/emit-build-report/1-original/IthWord.java
+++ b/native-image/emit-build-report/1-original/IthWord.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+public class IthWord {
+  public static String input = "foo     \t , \t bar ,      baz";
+
+   public static void main(String[] args) {
+       if (args.length < 1) {
+           System.out.println("Word index is required, please provide one first.");
+           return;
+       }
+       int i = Integer.parseInt(args[0]);
+
+       // Extract the word at the given index.
+       String[] words = input.split("\\s+,\\s+");
+       if (i >= words.length) {
+           System.out.printf("Cannot get the word #%d, there are only %d words.%n", i, words.length);
+           return;
+       }
+
+       System.out.printf("Word #%d is %s.%n", i, words[i]);
+   }
+}

--- a/native-image/emit-build-report/2-optimized/IthWord.java
+++ b/native-image/emit-build-report/2-optimized/IthWord.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+public class IthWord {
+    public static String input = "foo     \t , \t bar ,      baz";
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Word index is required, please provide one first.");
+            return;
+        }
+        int i = Integer.parseInt(args[0]);
+
+        // Extract the word at the given index.
+        String[] words = input.split("\\s+,\\s+");
+        if (i >= words.length) {
+            // Use System.out.println instead of System.out.printf.
+            System.out.println("Cannot get the word #" + i + ", there are only " + words.length + " words.");
+            return;
+        }
+
+        // Use System.out.println instead of System.out.printf.
+        System.out.println("Word #" + i + " is " + words[i] + ".");
+    }
+}

--- a/native-image/emit-build-report/3-optimized/IthWord.java
+++ b/native-image/emit-build-report/3-optimized/IthWord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+public class IthWord {
+    public static String input = "foo     \t , \t bar ,      baz";
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+           System.out.println("Word index is required, please provide one first.");
+           return;
+        }
+        int i = Integer.parseInt(args[0]);
+
+        // Extract the word at the given index using String.substring and String.indexOf.
+        String word = input;
+        int j = i, index;
+        while (j > 0) {
+           index = word.indexOf(',');
+           if (index < 0) {
+               // Use System.out.println instead of System.out.printf.
+               System.out.println("Cannot get the word #" + i + ", there are only " + (i - j + 1) + " words.");
+               return;
+           }
+           word = word.substring(index + 1);
+           j--;
+        }
+        index = word.indexOf(',');
+        if (index > 0) {
+           word = word.substring(0, word.indexOf(','));
+        }
+        word = word.trim();
+
+        // Use System.out.println instead of System.out.printf.
+        System.out.println("Word #" + i + " is " + word + ".");
+    }
+}

--- a/native-image/emit-build-report/README.md
+++ b/native-image/emit-build-report/README.md
@@ -1,0 +1,3 @@
+# Optimize Size of a Native Executable using Build Reports
+
+You can find the steps to run this demo on [the website](https://www.graalvm.org/latest/reference-manual/native-image/guides/optimize-native-executable-size-using-build-report/).

--- a/native-image/emit-build-report/run.sh
+++ b/native-image/emit-build-report/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+
+cd 1-original
+javac IthWord.java
+native-image IthWord --emit build-report
+./ithword 1
+
+cd ../2-optimized
+javac IthWord.java
+native-image IthWord --emit build-report
+./ithword 1
+
+cd ../3-optimized
+javac IthWord.java
+native-image IthWord --emit build-report
+./ithword 1


### PR DESCRIPTION
Add demo checks for https://www.graalvm.org/latest/reference-manual/native-image/guides/optimize-native-executable-size-using-build-report/
The continuation of https://github.com/graalvm/graalvm-demos/pull/300.
The goal is to sort the demos by categories (Native Image, referenced from blog posts, etc.)