### PR TITLE
[GR-60094] Add demo for Optimize Memory Footprint of a Native Executable guide.

### DIFF
--- a/.github/workflows/native-image-optimize-memory-footprint.yml
+++ b/.github/workflows/native-image-optimize-memory-footprint.yml
@@ -1,0 +1,35 @@
+name: native-image/optimize-memory
+on:
+  push:
+    paths:
+      - 'native-image/optimize-memory/**'
+      - '.github/workflows/native-image-optimize-memory.yml'
+  pull_request:
+    paths:
+      - 'native-image/optimize-memory/**'
+      - '.github/workflows/native-image-optimize-memory.yml'
+  schedule:
+    - cron: "0 0 1 * *" # run every month
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  run:
+    name: Run 'native-image/optimize-memory'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        java-version: ['21', '24-ea']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: 'true'
+      - name: Run 'native-image/optimize-memory'
+        run: |
+          cd native-image/optimize-memory
+          ./run.sh

--- a/native-image/optimize-memory/.gitignore
+++ b/native-image/optimize-memory/.gitignore
@@ -1,0 +1,5 @@
+.class
+testgc-serial
+testgc-g1
+testgc-epsilon
+testgc-maxheapset-g1

--- a/native-image/optimize-memory/README.md
+++ b/native-image/optimize-memory/README.md
@@ -1,0 +1,3 @@
+# Optimize Memory Footprint of a Native Executable
+
+You can find the steps to run this demo on [the website](https://www.graalvm.org/jdk24/reference-manual/native-image/guides/optimize-memory-footprint/).

--- a/native-image/optimize-memory/StringManipulation.java
+++ b/native-image/optimize-memory/StringManipulation.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import java.util.ArrayDeque;
+
+public class StringManipulation {
+
+    public static void main(String[] args) {
+        System.out.println("Starting string manipulation GC stress test...");
+
+        // Parse arguments
+        int iterations = 1000000;
+        int numKeptAliveObjects = 100000;
+        if (args.length > 0) {
+            iterations = Integer.parseInt(args[0]);
+        }
+        if (args.length > 1) {
+            numKeptAliveObjects = Integer.parseInt(args[1]);
+        }
+
+        ArrayDeque<String[]> aliveData = new ArrayDeque<String[]>(numKeptAliveObjects + 1);
+        for (int i = 0; i < iterations; i++) {
+            // Simulate log entry generation and log entry splitting. The last n entries are kept in memory.
+            String base = "log-entry";
+            StringBuilder builder = new StringBuilder(base);
+
+            for (int j = 0; j < 100; j++) {
+                builder.append("-").append(System.nanoTime());
+            }
+
+            String logEntry = builder.toString();
+            String[] parts = logEntry.split("-");
+
+            aliveData.addLast(parts);
+            if (aliveData.size() > numKeptAliveObjects) {
+                aliveData.removeFirst();
+            }
+
+            // Periodically log progress
+            if (i % 100000 == 0) {
+                System.out.println("Processed " + i + " log entries");
+            }
+        }
+
+        System.out.println("String manipulation GC stress test completed: " + aliveData.hashCode());
+    }
+}

--- a/native-image/optimize-memory/run.sh
+++ b/native-image/optimize-memory/run.sh
@@ -15,7 +15,7 @@ native-image -Ob --gc=G1 -o testgc-g1 StringManipulation
 
 # Build a Native Image with Epsilon GC
 native-image -Ob --gc=epsilon -o testgc-epsilon StringManipulation
-/usr/bin/time ./testgc-epsilon 3200000 50000
+/usr/bin/time ./testgc-epsilon 100000 50000
 
 # Build a Native Image Setting the Maximum Heap Size
 # At run time

--- a/native-image/optimize-memory/run.sh
+++ b/native-image/optimize-memory/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+# Compile and run the application on HotSpot
+javac StringManipulation.java
+/usr/bin/time java StringManipulation 500000 50000
+
+# Build a Native Image with Serial GC (default)
+native-image -Ob -o testgc-serial StringManipulation
+/usr/bin/time ./testgc-serial 500000 50000 -XX:+PrintGC
+
+# Build a Native Image with G1 GC
+native-image -Ob --gc=G1 -o testgc-g1 StringManipulation
+/usr/bin/time ./testgc-g1 500000 50000 -XX:+PrintGC
+
+# Build a Native Image with Epsilon GC
+native-image -Ob --gc=epsilon -o testgc-epsilon StringManipulation
+/usr/bin/time ./testgc-epsilon 3200000 50000
+
+# Build a Native Image Setting the Maximum Heap Size
+# At run time
+/usr/bin/time ./testgc-g1 -Xmx512m 500000 50000
+# At build Time
+native-image -Ob --gc=G1 -R:MaxHeapSize=512m -o testgc-maxheapset-g1 StringManipulation
+/usr/bin/time ./testgc-maxheapset-g1 500000 50000


### PR DESCRIPTION
Add demo checks for https://www.graalvm.org/jdk24/reference-manual/native-image/guides/optimize-memory-footprint/
The continuation of https://github.com/graalvm/graalvm-demos/pull/300.
The goal is to sort the demos by categories (Native Image, referenced from blog posts, etc.)