### PR TITLE
Fix Wasm backend javac demo

### DIFF
--- a/native-image/wasm-javac/README.md
+++ b/native-image/wasm-javac/README.md
@@ -7,7 +7,7 @@ This demo illustrates how to use the new experimental WebAssembly backend for Gr
 This demo requires:
 
 1. An [Early Access Build](https://github.com/graalvm/oracle-graalvm-ea-builds) of Oracle GraalVM for JDK 25 or later.
-    For example, using SDKMAN!: `sdk install java 25.ea.15-graal`
+    For example, using SDKMAN!: `sdk install java 25.ea.18-graal`
 2. The [Binaryen toolchain](https://github.com/WebAssembly/binaryen) in version 119 or later and on the system path.
     For example, using Homebrew: `brew install binaryen`
 

--- a/native-image/wasm-javac/src/main/java/com/example/JavacMain.java
+++ b/native-image/wasm-javac/src/main/java/com/example/JavacMain.java
@@ -13,9 +13,9 @@ import java.util.List;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 
-import org.graalvm.aotjs.api.JS;
-import org.graalvm.aotjs.api.JSNumber;
-import org.graalvm.aotjs.api.JSObject;
+import org.graalvm.webimage.api.JS;
+import org.graalvm.webimage.api.JSNumber;
+import org.graalvm.webimage.api.JSObject;
 
 public class JavacMain {
     public static void main(String[] args) throws IOException {

--- a/native-image/wasm-javac/src/main/java/com/example/WebMain.java
+++ b/native-image/wasm-javac/src/main/java/com/example/WebMain.java
@@ -20,10 +20,10 @@ import javax.tools.JavaFileObject;
 import com.example.JavacCompilerWrapper;
 import com.example.JavacCompilerWrapper.FileContent;
 import com.example.preload.PreLoadedFiles;
-import org.graalvm.aotjs.api.JS;
-import org.graalvm.aotjs.api.JSBoolean;
-import org.graalvm.aotjs.api.JSObject;
-import org.graalvm.aotjs.api.JSString;
+import org.graalvm.webimage.api.JS;
+import org.graalvm.webimage.api.JSBoolean;
+import org.graalvm.webimage.api.JSObject;
+import org.graalvm.webimage.api.JSString;
 
 import com.sun.tools.javap.JavapTask;
 


### PR DESCRIPTION
The packages for the `@JS` annotation were renamed. With newer EA builds the build is now failing.