### PR TITLE
Update javac demo to use JS interop API shipped with GraalVM

### DIFF
--- a/native-image/wasm-javac/README.md
+++ b/native-image/wasm-javac/README.md
@@ -7,7 +7,7 @@ This demo illustrates how to use the new experimental WebAssembly backend for Gr
 This demo requires:
 
 1. An [Early Access Build](https://github.com/graalvm/oracle-graalvm-ea-builds) of Oracle GraalVM for JDK 25 or later.
-    For example, using SDKMAN!: `sdk install java 25.ea.18-graal`
+    For example, using SDKMAN!: `sdk install java 25.ea.26-graal`
 2. The [Binaryen toolchain](https://github.com/WebAssembly/binaryen) in version 119 or later and on the system path.
     For example, using Homebrew: `brew install binaryen`
 

--- a/native-image/wasm-javac/pom.xml
+++ b/native-image/wasm-javac/pom.xml
@@ -62,18 +62,6 @@
         </plugins>
     </build>
 
-    <dependencies>
-        <dependency>
-            <artifactId>someArtifactId</artifactId>
-            <groupId>someGroupId</groupId>
-            <version>1.0</version>
-            <scope>system</scope>
-            <systemPath>
-                ${java.home}/lib/svm/tools/svm-wasm/builder/svm-wasm-api.jar
-            </systemPath>
-        </dependency>
-    </dependencies>
-
     <profiles>
         <profile>
             <id>native</id>


### PR DESCRIPTION
The JS interop API will soon be moved, making the system scope used in the demo obsolete. Once we get an ea build for that this can be merge