### PR TITLE
Remove workaround for passing functional interfaces to @JS methods

### DIFF
--- a/native-image/wasm-javac/README.md
+++ b/native-image/wasm-javac/README.md
@@ -6,8 +6,8 @@ This demo illustrates how to use the new experimental WebAssembly backend for Gr
 
 This demo requires:
 
-1. An [Early Access Build](https://github.com/graalvm/oracle-graalvm-ea-builds) of Oracle GraalVM for JDK 25 or later.
-    For example, using SDKMAN!: `sdk install java 25.ea.26-graal`
+1. An [Early Access Build](https://github.com/graalvm/oracle-graalvm-ea-builds) of Oracle GraalVM for JDK 26 or later.
+    For example, using SDKMAN!: `sdk install java 26.ea.3-graal`
 2. The [Binaryen toolchain](https://github.com/WebAssembly/binaryen) in version 119 or later and on the system path.
     For example, using Homebrew: `brew install binaryen`
 

--- a/native-image/wasm-javac/src/main/java/com/example/WebMain.java
+++ b/native-image/wasm-javac/src/main/java/com/example/WebMain.java
@@ -37,14 +37,6 @@ public class WebMain {
     public static void main(String[] args) {
         // Ensure file manager is initialized
         JavacCompilerWrapper.getFm();
-        try {
-            // TODO GR-62854 Here to ensure handleEvent and run is generated. Remove once objects
-            // passed to @JS methods automatically have their SAM registered.
-            sink(EventHandler.class.getDeclaredMethod("handleEvent", JSObject.class));
-            sink(Runnable.class.getDeclaredMethod("run"));
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        }
 
         addEventListener(COMPILE_BUTTON, "click", e -> compileCallback());
         addEventListener(INPUT, "keydown", e -> {
@@ -66,9 +58,6 @@ public class WebMain {
             }
         });
     }
-
-    @JS("")
-    private static native void sink(Object o);
 
     /**
      * Runs the given {@link Runnable} in {@code setTimeout} without delay.


### PR DESCRIPTION
The workaround is no longer needed once the next early access build containing the fix is published 

TODO:

* [x] Update the README with the right EA build version once released