### PR TITLE
Use classesDirectory to exclude the main .jar from the base layers

### DIFF
--- a/native-image/microservices/micronaut-hello-rest-maven-layered/base-layer/pom.xml
+++ b/native-image/microservices/micronaut-hello-rest-maven-layered/base-layer/pom.xml
@@ -29,28 +29,10 @@
                 </executions>
                 <configuration>
                     <imageName>libjavabaselayer</imageName>
-                    <buildArgs>
-                        <buildArg>-cp ${project.basedir}/base_layer_config</buildArg>
-                    </buildArgs>
+                    <classpath>
+                        <path>${project.basedir}/base_layer_config</path>
+                    </classpath>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <configuration>
-                            <groupId>${project.groupId}</groupId>
-                            <file>${project.build.directory}/${project.artifactId}-${project.version}.jar</file>
-                            <artifactId>base-layer</artifactId>
-                            <packaging>jar</packaging>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/native-image/microservices/micronaut-hello-rest-maven-layered/pom.xml
+++ b/native-image/microservices/micronaut-hello-rest-maven-layered/pom.xml
@@ -24,13 +24,6 @@
     <exec.mainClass>example.micronaut.Application</exec.mainClass>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>central</id>
-      <url>https://repo.maven.apache.org/maven2</url>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>io.micronaut</groupId>
@@ -144,6 +137,7 @@
             <configuration>
               <imageName>libmicronautbaselayer</imageName>
               <mainClass>.</mainClass>
+              <classesDirectory>null</classesDirectory>
               <buildArgs>
                 <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
                 <buildArg>-H:LayerCreate=base-layer.nil,module=java.base,package=io.micronaut.*,package=io.netty.*,package=jakarta.*,package=com.fasterxml.jackson.*,package=org.slf4j.*,package=reactor.*,package=org.reactivestreams.*</buildArg>
@@ -154,48 +148,11 @@
               </buildArgs>
             </configuration>
           </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <exclude>**/example/micronaut/**</exclude>
-              </excludes>
-              <testExcludes>
-                <exclude>**/example/micronaut/**</exclude>
-              </testExcludes>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-install-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>install</phase>
-                <goals>
-                  <goal>install-file</goal>
-                </goals>
-                <configuration>
-                  <groupId>${project.groupId}</groupId>
-                  <file>${project.build.directory}/${project.artifactId}-${project.version}.jar</file>
-                  <artifactId>micronaut-base-layer</artifactId>
-                  <packaging>jar</packaging>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
     <profile>
       <id>app-layer</id>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>micronaut-base-layer</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
       <build>
         <directory>${project.basedir}/app-layer-target</directory>
         <plugins>
@@ -245,13 +202,6 @@
     </profile>
     <profile>
       <id>micronaut-app-layer</id>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>base-layer</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-      </dependencies>
       <build>
         <directory>${project.basedir}/app-layer-target</directory>
         <plugins>
@@ -300,5 +250,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/native-image/microservices/spring-hello-rest-maven-layered/base-layer/pom.xml
+++ b/native-image/microservices/spring-hello-rest-maven-layered/base-layer/pom.xml
@@ -8,10 +8,9 @@
     <version>0.1</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <native.maven.plugin.version>0.11.2</native.maven.plugin.version>
-        <packaging>jar</packaging>
     </properties>
     <build>
         <plugins>
@@ -29,9 +28,9 @@
                 </executions>
                 <configuration>
                     <imageName>libjavabaselayer</imageName>
-                    <buildArgs>
-                        <buildArg>-cp ${project.basedir}/base_layer_config</buildArg>
-                    </buildArgs>
+                    <classpath>
+                        <path>${project.basedir}/base_layer_config</path>
+                    </classpath>
                 </configuration>
             </plugin>
         </plugins>

--- a/native-image/microservices/spring-hello-rest-maven-layered/spring-application-layer/pom.xml
+++ b/native-image/microservices/spring-hello-rest-maven-layered/spring-application-layer/pom.xml
@@ -12,30 +12,11 @@
     <artifactId>spring-hello-rest-maven-layered</artifactId>
     <version>0.1</version>
     <description>Layered native demo project for Spring Boot</description>
-    <url/>
-    <licenses>
-        <license/>
-    </licenses>
-    <developers>
-        <developer/>
-    </developers>
-    <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
-    </scm>
     <properties>
         <java.version>25</java.version>
         <native.maven.plugin.version>0.11.2</native.maven.plugin.version>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>example.spring</groupId>
-            <artifactId>base-layer</artifactId>
-            <version>0.1</version>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -91,13 +72,6 @@
         </profile>
         <profile>
             <id>app-layer</id>
-            <dependencies>
-                    <dependency>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>base-layer</artifactId>
-                    <version>${project.version}</version>
-                    </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Thanks to `<classesDirectory>null</classesDirectory>`, it's possible to completely exclude the jar from the base layer code, which is useful to ensure no application layer code, or base layer configuration code is included in the base layer.

This is currently not possible for base layer with only java base (no other dependency), but it works for the Micronaut demo as it has all the Micronaut dependencies.

This PR simplifies the pom files.